### PR TITLE
Configure Supabase environment resolution

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,9 @@
+# Public Supabase credentials used by the Next.js app.
+# Replace the placeholder values with your Supabase project information.
+NEXT_PUBLIC_SUPABASE_URL=https://fsakwsavwoaakljdrtig.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Optional: server-only aliases if you prefer not to expose NEXT_PUBLIC variables.
+# SUPABASE_URL= # https://fsakwsavwoaakljdrtig.supabase.co
+# SUPABASE_ANON_KEY= # your-supabase-anon-key
+# SUPABASE_KEY= # legacy fallback for anon key

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/app/admin/about/page.tsx
+++ b/app/admin/about/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/components/admin/content-editor"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import type { AboutContent } from "@/lib/types"
 
 function toNullableString(value: string | null | undefined) {
@@ -16,9 +17,7 @@ function toNullableString(value: string | null | undefined) {
 }
 
 export default function AboutAdminPage() {
-  const isSupabaseConfigured = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  )
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
   const [aboutData, setAboutData] = useState<Partial<AboutContent>>({
     title: "",
     content: "",

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -14,14 +14,13 @@ import { Save, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 
 export default function NewEventPage() {
   const { toast } = useToast()
   const router = useRouter()
   const [loading, setLoading] = useState(false)
-  const isSupabaseConfigured = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  )
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
   const [formData, setFormData] = useState({
     title: "",
     description: "",

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -9,6 +9,7 @@ import { Plus, Edit, Trash2, Calendar, MapPin } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { AdminNavigation } from "@/components/admin/admin-navigation"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 
 interface Event {
   id: string
@@ -26,9 +27,7 @@ export default function AdminEventsPage() {
   const { toast } = useToast()
   const [events, setEvents] = useState<Event[]>([])
   const [loading, setLoading] = useState(true)
-  const isSupabaseConfigured = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  )
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
 
   const showSupabaseToast = () => {
     toast({

--- a/app/admin/hero/page.tsx
+++ b/app/admin/hero/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/components/admin/content-editor"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import type { HeroContent } from "@/lib/types"
 
 function toNullableString(value: string | null | undefined) {
@@ -16,9 +17,7 @@ function toNullableString(value: string | null | undefined) {
 }
 
 export default function HeroAdminPage() {
-  const isSupabaseConfigured = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  )
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
   const [heroData, setHeroData] = useState<Partial<HeroContent>>({
     title: "",
     subtitle: "",

--- a/app/admin/magazine/new/page.tsx
+++ b/app/admin/magazine/new/page.tsx
@@ -14,14 +14,13 @@ import { Save, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 
 export default function NewMagazineIssuePage() {
   const { toast } = useToast()
   const router = useRouter()
   const [loading, setLoading] = useState(false)
-  const isSupabaseConfigured = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  )
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
   const [formData, setFormData] = useState({
     title: "",
     volume: 1,

--- a/app/admin/magazine/page.tsx
+++ b/app/admin/magazine/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Plus, Edit, Trash2, Eye, FileText } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 
 interface MagazineIssue {
   id: string
@@ -26,9 +27,7 @@ export default function AdminMagazinePage() {
   const { toast } = useToast()
   const [issues, setIssues] = useState<MagazineIssue[]>([])
   const [loading, setLoading] = useState(true)
-  const isSupabaseConfigured = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  )
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
 
   const showSupabaseToast = () => {
     toast({

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,5 +1,7 @@
 import { createClient as createSupabaseClient } from "@supabase/supabase-js"
 
+import { getSupabaseConfig } from "./config"
+
 type SupabaseClient = ReturnType<typeof createSupabaseClient>
 
 let cachedClient: SupabaseClient | null = null
@@ -41,10 +43,9 @@ function createStubClient(): SupabaseClient {
 }
 
 export function createClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const config = getSupabaseConfig()
 
-  if (!url || !anonKey) {
+  if (!config) {
     if (!cachedStubClient) {
       cachedStubClient = createStubClient()
     }
@@ -52,7 +53,7 @@ export function createClient() {
   }
 
   if (!cachedClient) {
-    cachedClient = createSupabaseClient(url, anonKey)
+    cachedClient = createSupabaseClient(config.url, config.anonKey)
   }
   return cachedClient
 }

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,0 +1,48 @@
+const SUPABASE_URL_ENV_KEYS = ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL"] as const
+const SUPABASE_ANON_KEY_ENV_KEYS = [
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_KEY",
+] as const
+
+export type SupabaseConfig = {
+  url: string
+  anonKey: string
+}
+
+function readEnvValue(keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key as keyof NodeJS.ProcessEnv]
+    if (typeof value === "string") {
+      const trimmed = value.trim()
+      if (trimmed.length > 0) {
+        return trimmed
+      }
+    }
+  }
+
+  return undefined
+}
+
+export function getSupabaseConfig(): SupabaseConfig | null {
+  const url = readEnvValue(SUPABASE_URL_ENV_KEYS)
+  const anonKey = readEnvValue(SUPABASE_ANON_KEY_ENV_KEYS)
+
+  if (!url || !anonKey) {
+    return null
+  }
+
+  return { url, anonKey }
+}
+
+export function isSupabaseEnvConfigured(): boolean {
+  return getSupabaseConfig() !== null
+}
+
+export function getSupabaseUrl(): string | undefined {
+  return readEnvValue(SUPABASE_URL_ENV_KEYS)
+}
+
+export function getSupabaseAnonKey(): string | undefined {
+  return readEnvValue(SUPABASE_ANON_KEY_ENV_KEYS)
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,10 +1,11 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
-import { isSupabaseConfigured } from "@/lib/supabase/server"
+import { getSupabaseConfig } from "./config"
 
 export async function updateSession(request: NextRequest) {
-  if (!isSupabaseConfigured()) {
+  const config = getSupabaseConfig()
+  if (!config) {
     return NextResponse.next({ request })
   }
 
@@ -13,8 +14,8 @@ export async function updateSession(request: NextRequest) {
   })
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    config.url,
+    config.anonKey,
     {
       cookies: {
         getAll() {

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,8 +1,10 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 
+import { getSupabaseConfig } from "./config"
+
 export function isSupabaseConfigured() {
-  return Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+  return getSupabaseConfig() !== null
 }
 
 /**
@@ -11,13 +13,19 @@ export function isSupabaseConfigured() {
  * it.
  */
 export async function createClient() {
-  if (!isSupabaseConfigured()) {
-    throw new Error("Supabase environment variables are not configured")
+  const config = getSupabaseConfig()
+  if (!config) {
+    throw new Error(
+      [
+        "Supabase environment variables are not configured.",
+        "Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY (or their SUPABASE_URL/SUPABASE_ANON_KEY equivalents).",
+      ].join(" "),
+    )
   }
 
   const cookieStore = await cookies()
 
-  return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+  return createServerClient(config.url, config.anonKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll()


### PR DESCRIPTION
## Summary
- add a shared Supabase config helper that resolves environment variables with sensible fallbacks
- update Supabase clients, middleware, and admin UI checks to rely on the shared configuration helper
- document the required Supabase credentials in a tracked `.env.local.example`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ec017024832f90fa022a155b923a