### PR TITLE
Fix magazine issue creation fields for Supabase schema

### DIFF
--- a/app/admin/magazine/new/page.tsx
+++ b/app/admin/magazine/new/page.tsx
@@ -23,12 +23,12 @@ export default function NewMagazineIssuePage() {
   const isSupabaseConfigured = isSupabaseEnvConfigured()
   const [formData, setFormData] = useState({
     title: "",
-    volume: 1,
-    issue: 1,
+    issue_number: "",
     description: "",
     cover_image_url: "",
     pdf_url: "",
-    published_date: new Date().toISOString().split("T")[0],
+    publication_date: new Date().toISOString().split("T")[0],
+    is_featured: false,
     is_active: true,
   })
 
@@ -46,12 +46,33 @@ export default function NewMagazineIssuePage() {
     setLoading(true)
 
     try {
+      const payload = {
+        title: formData.title.trim(),
+        description: formData.description.trim() || null,
+        cover_image_url: formData.cover_image_url.trim() || null,
+        pdf_url: formData.pdf_url.trim() || null,
+        issue_number: formData.issue_number.trim(),
+        publication_date: formData.publication_date,
+        is_featured: formData.is_featured,
+        is_active: formData.is_active,
+      }
+
+      if (!payload.title || !payload.issue_number || !payload.publication_date) {
+        toast({
+          title: "Missing required information",
+          description: "Title, issue number, and publication date are required to create a magazine issue.",
+          variant: "destructive",
+        })
+        setLoading(false)
+        return
+      }
+
       const response = await fetch("/api/magazines", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify(payload),
       })
 
       if (response.ok) {
@@ -119,36 +140,24 @@ export default function NewMagazineIssuePage() {
               />
             </div>
 
-            <div className="grid md:grid-cols-3 gap-6">
+            <div className="grid md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <Label htmlFor="volume">Volume *</Label>
+                <Label htmlFor="issue_number">Issue Number *</Label>
                 <Input
-                  id="volume"
-                  type="number"
-                  value={formData.volume}
-                  onChange={(e) => handleChange("volume", Number.parseInt(e.target.value) || 1)}
-                  min="1"
+                  id="issue_number"
+                  value={formData.issue_number}
+                  onChange={(e) => handleChange("issue_number", e.target.value)}
+                  placeholder="Vol. 15, Issue 3"
                   required
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="issue">Issue Number *</Label>
+                <Label htmlFor="publication_date">Publication Date *</Label>
                 <Input
-                  id="issue"
-                  type="number"
-                  value={formData.issue}
-                  onChange={(e) => handleChange("issue", Number.parseInt(e.target.value) || 1)}
-                  min="1"
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="published_date">Published Date *</Label>
-                <Input
-                  id="published_date"
+                  id="publication_date"
                   type="date"
-                  value={formData.published_date}
-                  onChange={(e) => handleChange("published_date", e.target.value)}
+                  value={formData.publication_date}
+                  onChange={(e) => handleChange("publication_date", e.target.value)}
                   required
                 />
               </div>
@@ -187,13 +196,23 @@ export default function NewMagazineIssuePage() {
               </div>
             </div>
 
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="is_active"
-                checked={formData.is_active}
-                onCheckedChange={(checked) => handleChange("is_active", checked)}
-              />
-              <Label htmlFor="is_active">Publish immediately</Label>
+            <div className="space-y-4">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="is_featured"
+                  checked={formData.is_featured}
+                  onCheckedChange={(checked) => handleChange("is_featured", checked)}
+                />
+                <Label htmlFor="is_featured">Feature this issue on the magazine page</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="is_active"
+                  checked={formData.is_active}
+                  onCheckedChange={(checked) => handleChange("is_active", checked)}
+                />
+                <Label htmlFor="is_active">Publish immediately</Label>
+              </div>
             </div>
 
             <Button type="submit" disabled={loading || !isSupabaseConfigured} className="w-full">

--- a/app/admin/magazine/page.tsx
+++ b/app/admin/magazine/page.tsx
@@ -13,14 +13,15 @@ import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 interface MagazineIssue {
   id: string
   title: string
-  volume: number
-  issue: number
-  description: string
-  cover_image_url: string
-  pdf_url: string
-  published_date: string
+  description: string | null
+  cover_image_url: string | null
+  pdf_url: string | null
+  issue_number: string | null
+  publication_date: string | null
+  is_featured: boolean
   is_active: boolean
   created_at: string
+  updated_at: string
 }
 
 export default function AdminMagazinePage() {
@@ -195,18 +196,21 @@ export default function AdminMagazinePage() {
                       />
                     )}
                     <div className="flex-1">
-                      <div className="flex items-center space-x-2 mb-2">
+                      <div className="flex flex-wrap items-center gap-2 mb-2">
                         <h3 className="text-lg font-semibold text-foreground">{issue.title}</h3>
                         <Badge variant={issue.is_active ? "default" : "secondary"}>
                           {issue.is_active ? "Active" : "Inactive"}
                         </Badge>
+                        {issue.is_featured && <Badge variant="outline">Featured</Badge>}
                       </div>
                       <p className="text-sm text-muted-foreground mb-2">
-                        Volume {issue.volume}, Issue {issue.issue}
+                        {issue.issue_number ? issue.issue_number : "Issue number not set"}
                       </p>
-                      <p className="text-sm text-muted-foreground mb-2">{issue.description}</p>
+                      {issue.description && (
+                        <p className="text-sm text-muted-foreground mb-2">{issue.description}</p>
+                      )}
                       <p className="text-xs text-muted-foreground">
-                        Published: {new Date(issue.published_date).toLocaleDateString()}
+                        Published: {issue.publication_date ? new Date(issue.publication_date).toLocaleDateString() : "Not scheduled"}
                       </p>
                     </div>
                   </div>

--- a/app/api/magazines/route.ts
+++ b/app/api/magazines/route.ts
@@ -53,12 +53,38 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     console.log("[v0] Magazines API - creating article:", body)
 
+    const sanitizeOptionalString = (value: unknown) => {
+      if (typeof value !== "string") {
+        return null
+      }
+      const trimmed = value.trim()
+      return trimmed.length > 0 ? trimmed : null
+    }
+
+    if (typeof body.title !== "string" || typeof body.issue_number !== "string" || typeof body.publication_date !== "string") {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+    }
+
+    const newArticle = {
+      title: body.title.trim(),
+      description: sanitizeOptionalString(body.description),
+      cover_image_url: sanitizeOptionalString(body.cover_image_url),
+      pdf_url: sanitizeOptionalString(body.pdf_url),
+      issue_number: body.issue_number.trim(),
+      publication_date: body.publication_date.trim(),
+      is_featured: typeof body.is_featured === "boolean" ? body.is_featured : false,
+      is_active: typeof body.is_active === "boolean" ? body.is_active : true,
+    }
+
+    if (!newArticle.title || !newArticle.issue_number || !newArticle.publication_date) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 })
+    }
+
     const { data, error } = await supabase
       .from("magazine_articles")
       .insert({
-        ...body,
+        ...newArticle,
         user_id: user.id,
-        is_active: true,
       })
       .select()
       .single()


### PR DESCRIPTION
## Summary
- align the admin magazine creation form with the `magazine_articles` Supabase schema, including issue number, publication date, and feature toggle support
- sanitize and validate the `/api/magazines` POST payload so only supported columns are stored and required fields are enforced
- update the magazine management list to display issue numbers, featured state, and publication dates safely

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d504ab59c0832fb4df9b906f2fb311