### PR TITLE
Refine event workflows and call-to-actions

### DIFF
--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -1,0 +1,273 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useParams, useRouter } from "next/navigation"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { ArrowLeft, Save } from "lucide-react"
+
+import { useToast } from "@/hooks/use-toast"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
+
+interface EventFormData {
+  title: string
+  description: string
+  event_date: string
+  location: string
+  registration_url: string
+  image_url: string
+  is_active: boolean
+}
+
+interface EventResponse extends Partial<EventFormData> {
+  id: string
+  event_date?: string
+  is_active?: boolean
+}
+
+export default function EditEventPage() {
+  const params = useParams<{ id: string }>()
+  const eventId = params?.id
+  const router = useRouter()
+  const { toast } = useToast()
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
+
+  const [loading, setLoading] = useState(false)
+  const [initialLoading, setInitialLoading] = useState(true)
+  const [formData, setFormData] = useState<EventFormData>({
+    title: "",
+    description: "",
+    event_date: "",
+    location: "",
+    registration_url: "",
+    image_url: "",
+    is_active: true,
+  })
+
+  useEffect(() => {
+    if (!eventId) return
+
+    const fetchEvent = async () => {
+      setInitialLoading(true)
+      try {
+        const response = await fetch("/api/events")
+        if (!response.ok) {
+          throw new Error("Failed to fetch event details")
+        }
+
+        const events: EventResponse[] = await response.json()
+        const event = events.find((item) => item.id === eventId)
+
+        if (!event) {
+          toast({
+            title: "Event not found",
+            description: "We couldn't locate the requested event.",
+            variant: "destructive",
+          })
+          return
+        }
+
+        const formattedDate = event.event_date
+          ? new Date(event.event_date).toISOString().split("T")[0]
+          : ""
+
+        setFormData({
+          title: event.title || "",
+          description: event.description || "",
+          event_date: formattedDate,
+          location: event.location || "",
+          registration_url: event.registration_url || "",
+          image_url: event.image_url || "",
+          is_active: event.is_active ?? true,
+        })
+      } catch (error) {
+        console.error("Failed to load event", error)
+        toast({
+          title: "Error",
+          description: "Unable to load event details. Please try again later.",
+          variant: "destructive",
+        })
+      } finally {
+        setInitialLoading(false)
+      }
+    }
+
+    fetchEvent()
+  }, [eventId, toast])
+
+  const handleChange = (field: keyof EventFormData, value: string | boolean) => {
+    setFormData((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!eventId) return
+
+    if (!isSupabaseConfigured) {
+      toast({
+        title: "Supabase configuration required",
+        description: "Connect Supabase to enable editing events.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      const response = await fetch(`/api/events/${eventId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to update event")
+      }
+
+      toast({
+        title: "Success",
+        description: "Event updated successfully",
+      })
+      router.push("/admin/events")
+    } catch (error) {
+      console.error("Failed to update event", error)
+      toast({
+        title: "Error",
+        description: "Failed to update event",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <div className="flex items-center space-x-4 mb-8">
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/admin/events">
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Events Management
+          </Link>
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Edit Event</h1>
+          <p className="text-muted-foreground">Update details for your event</p>
+        </div>
+      </div>
+
+      {!isSupabaseConfigured && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertTitle>Event editing is unavailable</AlertTitle>
+          <AlertDescription>
+            Supabase credentials are not configured. Configure Supabase to edit event details.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Event Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {initialLoading ? (
+            <div className="py-12 text-center text-sm text-muted-foreground">Loading event details...</div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="title">Event Title *</Label>
+                <Input
+                  id="title"
+                  value={formData.title}
+                  onChange={(e) => handleChange("title", e.target.value)}
+                  placeholder="Global Civil Engineering Summit 2024"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="description">Description *</Label>
+                <Textarea
+                  id="description"
+                  value={formData.description}
+                  onChange={(e) => handleChange("description", e.target.value)}
+                  placeholder="Brief description of the event..."
+                  rows={4}
+                  required
+                />
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="event_date">Event Date *</Label>
+                  <Input
+                    id="event_date"
+                    type="date"
+                    value={formData.event_date}
+                    onChange={(e) => handleChange("event_date", e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="location">Location</Label>
+                  <Input
+                    id="location"
+                    value={formData.location}
+                    onChange={(e) => handleChange("location", e.target.value)}
+                    placeholder="San Francisco, CA"
+                  />
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="registration_url">Registration URL</Label>
+                  <Input
+                    id="registration_url"
+                    value={formData.registration_url}
+                    onChange={(e) => handleChange("registration_url", e.target.value)}
+                    placeholder="https://example.com/register"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="image_url">Event Image URL</Label>
+                  <Input
+                    id="image_url"
+                    value={formData.image_url}
+                    onChange={(e) => handleChange("image_url", e.target.value)}
+                    placeholder="https://example.com/event-image.jpg"
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="is_active"
+                  checked={formData.is_active}
+                  onCheckedChange={(checked) => handleChange("is_active", checked)}
+                />
+                <Label htmlFor="is_active">Published</Label>
+              </div>
+
+              <Button type="submit" disabled={loading || !isSupabaseConfigured} className="w-full">
+                <Save className="w-4 h-4 mr-2" />
+                {loading ? "Saving..." : "Save Changes"}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -135,7 +135,7 @@ export default function NewEventPage() {
                 <Label htmlFor="event_date">Event Date *</Label>
                 <Input
                   id="event_date"
-                  type="datetime-local"
+                  type="date"
                   value={formData.event_date}
                   onChange={(e) => handleChange("event_date", e.target.value)}
                   required

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,11 +1,26 @@
 import { Navigation } from "@/components/navigation"
 import { Footer } from "@/components/footer"
+import Link from "next/link"
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Calendar, MapPin, Users, Clock } from "lucide-react"
 
-const allEvents = [
+type EventStatus = "upcoming" | "past"
+
+interface EventInfo {
+  title: string
+  date: string
+  location: string
+  description: string
+  attendees: string
+  status: EventStatus
+  featured?: boolean
+  url: string
+}
+
+const allEvents: EventInfo[] = [
   {
     title: "Global Computer Engineering Summit 2024",
     date: "December 15-17, 2024",
@@ -15,6 +30,7 @@ const allEvents = [
     attendees: "500+ Expected",
     status: "upcoming",
     featured: true,
+    url: "https://example.com/register-global-summit",
   },
   {
     title: "AI & Machine Learning Workshop",
@@ -25,6 +41,7 @@ const allEvents = [
     attendees: "200+ Registered",
     status: "upcoming",
     featured: false,
+    url: "https://example.com/register-ai-workshop",
   },
   {
     title: "Student Innovation Competition",
@@ -34,6 +51,7 @@ const allEvents = [
     attendees: "150+ Participants",
     status: "upcoming",
     featured: false,
+    url: "https://example.com/register-innovation-competition",
   },
   {
     title: "Cybersecurity in IoT Devices",
@@ -43,6 +61,7 @@ const allEvents = [
     attendees: "120+ Attended",
     status: "past",
     featured: false,
+    url: "https://example.com/view-iot-workshop",
   },
   {
     title: "Blockchain Technology Symposium",
@@ -52,6 +71,7 @@ const allEvents = [
     attendees: "300+ Attended",
     status: "past",
     featured: false,
+    url: "https://example.com/view-blockchain-symposium",
   },
   {
     title: "Green Computing Initiative",
@@ -61,6 +81,7 @@ const allEvents = [
     attendees: "180+ Attended",
     status: "past",
     featured: false,
+    url: "https://example.com/view-green-computing",
   },
 ]
 
@@ -113,8 +134,15 @@ export default function EventsPage() {
                       </div>
                     </div>
 
-                    <Button className="w-full" size="sm">
-                      Register Now
+                    <Button
+                      asChild
+                      size="sm"
+                      variant="outline"
+                      className="w-full border border-input bg-white text-black hover:bg-muted"
+                    >
+                      <Link href={event.url} target="_blank" rel="noopener noreferrer">
+                        Register Now
+                      </Link>
                     </Button>
                   </CardContent>
                 </Card>
@@ -155,8 +183,14 @@ export default function EventsPage() {
                       </div>
                     </div>
 
-                    <Button variant="outline" className="w-full bg-transparent" size="sm">
-                      View Summary
+                    <Button
+                      asChild
+                      className="w-full bg-neutral-800 text-neutral-200 hover:bg-neutral-700"
+                      size="sm"
+                    >
+                      <Link href={event.url} target="_blank" rel="noopener noreferrer">
+                        View
+                      </Link>
                     </Button>
                   </CardContent>
                 </Card>

--- a/components/events-section.tsx
+++ b/components/events-section.tsx
@@ -3,7 +3,19 @@ import { Button } from "@/components/ui/button"
 import { Calendar, MapPin, Users } from "lucide-react"
 import Link from "next/link"
 
-const latestEvents = [
+type EventStatus = "upcoming" | "past"
+
+interface EventSummary {
+  title: string
+  date: string
+  location: string
+  description: string
+  attendees: string
+  status: EventStatus
+  url: string
+}
+
+const events: EventSummary[] = [
   {
     title: "Global Civil Engineering Summit 2024",
     date: "December 15-17, 2024",
@@ -11,6 +23,8 @@ const latestEvents = [
     description:
       "Join leading experts and students for three days of cutting-edge research presentations, workshops, and networking opportunities in infrastructure and construction.",
     attendees: "500+ Expected",
+    status: "upcoming",
+    url: "https://example.com/register-global-summit",
   },
   {
     title: "Sustainable Construction Workshop",
@@ -19,6 +33,8 @@ const latestEvents = [
     description:
       "Hands-on workshop covering the latest developments in sustainable construction practices and green building technologies.",
     attendees: "200+ Registered",
+    status: "upcoming",
+    url: "https://example.com/register-construction-workshop",
   },
   {
     title: "Student Innovation Competition",
@@ -26,10 +42,42 @@ const latestEvents = [
     location: "MIT, Boston",
     description: "Annual competition showcasing innovative projects from civil engineering students worldwide.",
     attendees: "150+ Participants",
+    status: "upcoming",
+    url: "https://example.com/register-innovation-competition",
+  },
+  {
+    title: "Coastal Resilience Seminar",
+    date: "September 12, 2024",
+    location: "Lisbon, Portugal",
+    description: "Insights from international experts on resilient coastal infrastructure projects.",
+    attendees: "180 Attended",
+    status: "past",
+    url: "https://example.com/view-coastal-resilience",
+  },
+  {
+    title: "Smart Cities Forum",
+    date: "August 4, 2024",
+    location: "Berlin, Germany",
+    description: "Case studies and lessons learned from smart infrastructure initiatives across Europe.",
+    attendees: "240 Attended",
+    status: "past",
+    url: "https://example.com/view-smart-cities",
+  },
+  {
+    title: "Bridge Engineering Hackathon",
+    date: "July 19, 2024",
+    location: "Chicago, USA",
+    description: "Student teams collaborated with industry mentors to prototype sustainable bridge designs.",
+    attendees: "120 Attended",
+    status: "past",
+    url: "https://example.com/view-bridge-hackathon",
   },
 ]
 
 export function EventsSection() {
+  const upcomingEvents = events.filter((event) => event.status === "upcoming")
+  const pastEvents = events.filter((event) => event.status === "past")
+
   return (
     <section id="events" className="py-20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -42,7 +90,7 @@ export function EventsSection() {
         </div>
 
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {latestEvents.map((event, index) => (
+          {upcomingEvents.map((event, index) => (
             <Card key={index}>
               <CardHeader>
                 <CardTitle className="text-lg">{event.title}</CardTitle>
@@ -65,8 +113,60 @@ export function EventsSection() {
                   </div>
                 </div>
 
-                <Button className="w-full" size="sm">
-                  Register Now
+                <Button
+                  asChild
+                  size="sm"
+                  variant="outline"
+                  className="w-full border border-input bg-white text-black hover:bg-muted"
+                >
+                  <Link href={event.url} target="_blank" rel="noopener noreferrer">
+                    Register Now
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="text-center my-16">
+          <h3 className="text-3xl md:text-4xl font-bold text-foreground mb-4">Past Highlights</h3>
+          <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
+            Explore summaries and resources from recent gatherings hosted by our global network.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {pastEvents.map((event, index) => (
+            <Card key={index} className="opacity-90">
+              <CardHeader>
+                <CardTitle className="text-lg">{event.title}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-muted-foreground text-sm leading-relaxed">{event.description}</p>
+
+                <div className="space-y-2">
+                  <div className="flex items-center text-sm text-muted-foreground">
+                    <Calendar className="w-4 h-4 mr-2" />
+                    {event.date}
+                  </div>
+                  <div className="flex items-center text-sm text-muted-foreground">
+                    <MapPin className="w-4 h-4 mr-2" />
+                    {event.location}
+                  </div>
+                  <div className="flex items-center text-sm text-muted-foreground">
+                    <Users className="w-4 h-4 mr-2" />
+                    {event.attendees}
+                  </div>
+                </div>
+
+                <Button
+                  asChild
+                  size="sm"
+                  className="w-full bg-neutral-800 text-neutral-200 hover:bg-neutral-700"
+                >
+                  <Link href={event.url} target="_blank" rel="noopener noreferrer">
+                    View
+                  </Link>
                 </Button>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- add an admin event editing form with date-only scheduling and consistent validation
- restrict the event creation form to calendar-date input instead of datetime selection
- refresh public events listings with upcoming and past categories that use contrasting register/view call-to-actions linking out

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d532d382f8832f8a29419676ac39d7