### PR TITLE
Fix event creation and updates with Supabase mapping

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { fallbackEvents } from "@/lib/fallback-data"
+import { buildEventMutationPayload, normalizeEventRecord } from "./utils"
 
 export const dynamic = "force-dynamic"
 
@@ -23,13 +24,7 @@ export async function GET() {
 
     console.log("[v0] Events API - Raw data from database:", data)
 
-    const transformedData =
-      data?.map((event) => ({
-        ...event,
-        event_date: event.date,
-        registration_url: event.contact_email ? `mailto:${event.contact_email}` : "",
-        is_active: event.is_active ?? true,
-      })) || []
+    const transformedData = data?.map((event) => normalizeEventRecord(event)) || []
 
     console.log("[v0] Events API - Transformed data:", transformedData)
     return NextResponse.json(transformedData.length > 0 ? transformedData : fallbackEvents)
@@ -58,14 +53,17 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     console.log("[v0] Events API - creating event:", body)
 
-    const { data, error } = await supabase
-      .from("events")
-      .insert({
-        ...body,
-        user_id: user.id,
-      })
-      .select()
-      .single()
+    const payloadWithUser = {
+      ...buildEventMutationPayload(body),
+      user_id: user.id,
+    }
+
+    let { data, error } = await supabase.from("events").insert(payloadWithUser).select().single()
+
+    if (error?.message?.includes("registration_url")) {
+      const { registration_url: _unused, ...fallbackPayload } = payloadWithUser
+      ;({ data, error } = await supabase.from("events").insert(fallbackPayload).select().single())
+    }
 
     if (error) {
       console.error("Error creating event:", error)

--- a/app/api/events/utils.ts
+++ b/app/api/events/utils.ts
@@ -1,0 +1,94 @@
+const REGISTRATION_MAILTO_PREFIX = "mailto:"
+
+function sanitizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+export function parseRegistrationValue(value: unknown): {
+  email: string | null
+  url: string | null
+} {
+  const trimmed = sanitizeString(value)
+  if (!trimmed) {
+    return { email: null, url: null }
+  }
+
+  if (trimmed.toLowerCase().startsWith(REGISTRATION_MAILTO_PREFIX)) {
+    const email = trimmed.slice(REGISTRATION_MAILTO_PREFIX.length).trim()
+    return { email: email || null, url: null }
+  }
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    return { email: null, url: trimmed }
+  }
+
+  if (trimmed.includes("@") && !trimmed.includes(" ")) {
+    return { email: trimmed, url: null }
+  }
+
+  return { email: null, url: trimmed }
+}
+
+export function buildEventMutationPayload(body: Record<string, unknown>): Record<string, unknown> {
+  const payload: Record<string, unknown> = {}
+
+  if ("title" in body && typeof body.title === "string") {
+    payload.title = body.title.trim()
+  }
+
+  if ("description" in body && typeof body.description === "string") {
+    payload.description = body.description.trim()
+  }
+
+  if ("event_date" in body) {
+    const rawDate = sanitizeString(body.event_date)
+    payload.date = rawDate || null
+  }
+
+  if ("location" in body) {
+    const location = sanitizeString(body.location)
+    payload.location = location || null
+  }
+
+  if ("image_url" in body) {
+    const imageUrl = sanitizeString(body.image_url)
+    payload.image_url = imageUrl || null
+  }
+
+  if ("is_active" in body && typeof body.is_active === "boolean") {
+    payload.is_active = body.is_active
+  }
+
+  if ("registration_url" in body) {
+    const { email, url } = parseRegistrationValue(body.registration_url)
+    payload.contact_email = email
+    payload.registration_url = url
+  }
+
+  return payload
+}
+
+export function normalizeEventRecord(event: Record<string, any>) {
+  const eventDate = event.event_date ?? event.date ?? null
+
+  const registrationUrl = (() => {
+    const directUrl = sanitizeString(event.registration_url)
+    if (directUrl) {
+      return directUrl
+    }
+
+    const contactEmail = sanitizeString(event.contact_email)
+    if (contactEmail) {
+      return `${REGISTRATION_MAILTO_PREFIX}${contactEmail}`
+    }
+
+    return ""
+  })()
+
+  return {
+    ...event,
+    event_date: eventDate,
+    registration_url: registrationUrl,
+    is_active: typeof event.is_active === "boolean" ? event.is_active : true,
+  }
+}


### PR DESCRIPTION
## Summary
- add shared utilities to normalize event payloads and map registration details to the Supabase schema
- update the events API routes to use the helper for consistent create/update behavior and better fallback handling
- implement PATCH support so the admin toggle can update event status while keeping timestamps in sync

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d53b823ae0832f8d1da79214a00133