### PR TITLE
Handle event updates when optional columns are absent

### DIFF
--- a/app/api/events/utils.ts
+++ b/app/api/events/utils.ts
@@ -103,17 +103,18 @@ function adjustPayloadForError(
 
   if (message.includes("registration_url") && "registration_url" in payload) {
     const { registration_url: _unusedRegistrationUrl, ...rest } = payload
-    const nextPayload = { ...rest }
-    if ("contact_email" in nextPayload) {
-      delete nextPayload.contact_email
-    }
-    return nextPayload
+    return { ...rest }
   }
 
   if (message.includes("contact_email") && "contact_email" in payload) {
     const nextPayload = { ...payload }
     delete nextPayload.contact_email
     return nextPayload
+  }
+
+  if (message.includes("is_active") && "is_active" in payload) {
+    const { is_active: _unusedIsActive, ...rest } = payload
+    return { ...rest }
   }
 
   if ((message.includes('"event_date"') || message.includes(" event_date")) && "event_date" in payload) {


### PR DESCRIPTION
## Summary
- adjust event mutation error handling so updates survive when optional columns are missing in the database
- keep contact email updates even when the registration_url column is absent
- allow updates to proceed by stripping the is_active flag if the column is unavailable

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d54b4555cc832f9ea932464820cdab