### PR TITLE
Allow admin events mutations without Supabase session

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient, createServiceRoleClient, isSupabaseConfigured } from "@/lib/supabase/server"
+import { isSupabaseConfigured } from "@/lib/supabase/server"
 
-import { buildEventMutationPayload, executeEventMutation } from "../utils"
+import { buildEventMutationPayload, executeEventMutation, resolveEventMutationContext } from "../utils"
 
 
 export const dynamic = "force-dynamic"
@@ -13,17 +13,12 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
     }
 
     const { id } = params
-    const supabase = await createClient()
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    const mutationContext = await resolveEventMutationContext()
+    if (mutationContext.error) {
+      return mutationContext.error
     }
 
-    const mutationClient = createServiceRoleClient() ?? supabase
+    const { client: mutationClient } = mutationContext
 
     const body = await request.json()
     console.log("[v0] Events API - updating event:", { id, body })
@@ -56,17 +51,12 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     }
 
     const { id } = params
-    const supabase = await createClient()
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    const mutationContext = await resolveEventMutationContext()
+    if (mutationContext.error) {
+      return mutationContext.error
     }
 
-    const mutationClient = createServiceRoleClient() ?? supabase
+    const { client: mutationClient } = mutationContext
 
     const body = await request.json()
     console.log("[v0] Events API - patching event:", { id, body })
@@ -100,17 +90,12 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     }
 
     const { id } = params
-    const supabase = await createClient()
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    const mutationContext = await resolveEventMutationContext()
+    if (mutationContext.error) {
+      return mutationContext.error
     }
 
-    const mutationClient = createServiceRoleClient() ?? supabase
+    const { client: mutationClient } = mutationContext
 
     console.log("[v0] Events API - deleting event:", id)
 

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,7 +1,12 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, createServiceRoleClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { fallbackEvents } from "@/lib/fallback-data"
-import { buildEventMutationPayload, executeEventMutation, normalizeEventRecord } from "./utils"
+import {
+  buildEventMutationPayload,
+  executeEventMutation,
+  normalizeEventRecord,
+  resolveEventMutationContext,
+} from "./utils"
 
 
 export const dynamic = "force-dynamic"
@@ -46,26 +51,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Supabase is not configured" }, { status: 503 })
     }
 
-    const supabase = await createClient()
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-    }
-
     const body = await request.json()
     console.log("[v0] Events API - creating event:", body)
 
-    const payloadWithUser = {
-      ...buildEventMutationPayload(body),
-      user_id: user.id,
+    const mutationContext = await resolveEventMutationContext()
+    if (mutationContext.error) {
+      return mutationContext.error
     }
 
+    const { client: mutationClient, userId } = mutationContext
 
-    const mutationClient = createServiceRoleClient() ?? supabase
+    const basePayload = buildEventMutationPayload(body)
+    const payloadWithUser = userId ? { ...basePayload, user_id: userId } : basePayload
 
     const { data, error } = await executeEventMutation(payloadWithUser, (payload) =>
       mutationClient.from("events").insert(payload).select().single(),

--- a/lib/event-utils.ts
+++ b/lib/event-utils.ts
@@ -1,0 +1,140 @@
+import type { EventItem } from "./types"
+
+function sanitizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function buildFallbackId(raw: Record<string, unknown>): string {
+  const title = sanitizeString(raw?.title)
+  const date = sanitizeString(raw?.event_date ?? raw?.date)
+  const base = title ? title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") : "event"
+  const suffix = date || sanitizeString(raw?.created_at) || sanitizeString(raw?.id)
+  return suffix ? `${base}-${suffix}` : `${base}-placeholder`
+}
+
+export function toEventItem(raw: Record<string, unknown>): EventItem {
+  const idValue = sanitizeString(raw?.id)
+  const description = sanitizeString(raw?.description)
+  const location = sanitizeString(raw?.location)
+  const registrationUrl = sanitizeString(raw?.registration_url)
+  const imageUrl = sanitizeString(raw?.image_url)
+  const contactEmail = sanitizeString(raw?.contact_email)
+
+  const eventDateValue = sanitizeString(raw?.event_date ?? raw?.date)
+
+  return {
+    id: idValue || buildFallbackId(raw),
+    title: sanitizeString(raw?.title) || "Untitled Event",
+    description,
+    event_date: eventDateValue || null,
+    location: location || null,
+    registration_url: registrationUrl || (contactEmail ? `mailto:${contactEmail}` : null),
+    image_url: imageUrl || null,
+    is_active:
+      typeof raw?.is_active === "boolean"
+        ? raw.is_active
+        : typeof (raw as { isActive?: boolean })?.isActive === "boolean"
+          ? (raw as { isActive?: boolean }).isActive!
+          : true,
+    created_at: sanitizeString(raw?.created_at) || null,
+    updated_at: sanitizeString(raw?.updated_at) || null,
+    contact_email: contactEmail || null,
+  }
+}
+
+export function parseEventDate(value: string | null | undefined): Date | null {
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date : null
+}
+
+export function formatEventDate(
+  value: string | null | undefined,
+  fallbackText = "Date to be announced",
+): string {
+  const date = parseEventDate(value)
+  if (!date) {
+    return fallbackText
+  }
+
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+}
+
+function compareAsc(a: EventItem, b: EventItem): number {
+  const dateA = parseEventDate(a.event_date)
+  const dateB = parseEventDate(b.event_date)
+
+  if (!dateA && !dateB) {
+    return a.title.localeCompare(b.title)
+  }
+  if (!dateA) {
+    return 1
+  }
+  if (!dateB) {
+    return -1
+  }
+
+  return dateA.getTime() - dateB.getTime()
+}
+
+function compareDesc(a: EventItem, b: EventItem): number {
+  const dateA = parseEventDate(a.event_date)
+  const dateB = parseEventDate(b.event_date)
+
+  if (!dateA && !dateB) {
+    return a.title.localeCompare(b.title)
+  }
+  if (!dateA) {
+    return 1
+  }
+  if (!dateB) {
+    return -1
+  }
+
+  return dateB.getTime() - dateA.getTime()
+}
+
+export function splitEventsByTime(events: EventItem[]): {
+  upcoming: EventItem[]
+  past: EventItem[]
+} {
+  const startOfToday = new Date()
+  startOfToday.setHours(0, 0, 0, 0)
+
+  const upcoming: EventItem[] = []
+  const past: EventItem[] = []
+
+  events.forEach((event) => {
+    if (event.is_active === false) {
+      return
+    }
+
+    const eventDate = parseEventDate(event.event_date)
+
+    if (!eventDate || eventDate >= startOfToday) {
+      upcoming.push(event)
+    } else {
+      past.push(event)
+    }
+  })
+
+  upcoming.sort(compareAsc)
+  past.sort(compareDesc)
+
+  return { upcoming, past }
+}
+
+export function isExternalUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url)
+}
+
+export function isMailtoLink(url: string): boolean {
+  return url.toLowerCase().startsWith("mailto:")
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -91,3 +91,17 @@ export interface LocalCommittee {
   created_at: string
   updated_at: string
 }
+
+export interface EventItem {
+  id: string
+  title: string
+  description: string
+  event_date: string | null
+  location: string | null
+  registration_url: string | null
+  image_url: string | null
+  is_active: boolean
+  created_at: string | null
+  updated_at: string | null
+  contact_email: string | null
+}


### PR DESCRIPTION
## Summary
- add a shared helper to reuse Supabase service-role access or fall back to authenticated clients when mutating events
- update the POST, PUT, PATCH, and DELETE event API endpoints to use the helper so admin writes work without an active Supabase session

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5564aa6b4832f928c36a764a22393