### PR TITLE
Ensure events mutations require authenticated user

### DIFF
--- a/app/api/events/utils.ts
+++ b/app/api/events/utils.ts
@@ -74,15 +74,10 @@ export function buildEventMutationPayload(body: Record<string, unknown>): Record
 }
 
 type MutationClientResult =
-  | { client: SupabaseClient; userId: string | null; error: null }
+  | { client: SupabaseClient; userId: string; error: null }
   | { client: null; userId: null; error: NextResponse }
 
 export async function resolveEventMutationContext(): Promise<MutationClientResult> {
-  const serviceClient = createServiceRoleClient()
-  if (serviceClient) {
-    return { client: serviceClient, userId: null, error: null }
-  }
-
   const supabase = await createClient()
   const {
     data: { user },
@@ -95,6 +90,11 @@ export async function resolveEventMutationContext(): Promise<MutationClientResul
       userId: null,
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
     }
+  }
+
+  const serviceClient = createServiceRoleClient()
+  if (serviceClient) {
+    return { client: serviceClient, userId: user.id, error: null }
   }
 
   return { client: supabase, userId: user.id, error: null }


### PR DESCRIPTION
## Summary
- require a resolved Supabase user before executing admin event mutations
- reuse the existing authenticated client for user discovery while still preferring the service role client for mutations

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d56e741270832fa719be3cd2bbb31b