### PR TITLE
Refresh admin dashboard navigation and layout

### DIFF
--- a/app/admin/committees/page.tsx
+++ b/app/admin/committees/page.tsx
@@ -4,11 +4,12 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Plus, Edit, Trash2, ExternalLink } from "lucide-react"
+import { Plus, Edit, Trash2, ExternalLink, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import type { LocalCommittee } from "@/lib/types"
 import Image from "next/image"
+import { AdminNavigation } from "@/components/admin/admin-navigation"
 
 export default function CommitteesAdminPage() {
   const [committees, setCommittees] = useState<LocalCommittee[]>([])
@@ -65,52 +66,57 @@ export default function CommitteesAdminPage() {
     }
   }
 
-  if (loading) {
-    return (
-      <div className="p-8 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent mx-auto"></div>
-          <p className="text-muted-foreground mt-4">Loading committees...</p>
+  const pageContent = (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-3">
+          <div>
+            <h1 className="text-3xl font-semibold text-foreground">Local Committees</h1>
+            <p className="text-muted-foreground">Manage local committees and their information</p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            asChild
+            className="w-full justify-start rounded-full text-muted-foreground transition hover:text-foreground sm:w-auto"
+          >
+            <Link href="/admin">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to dashboard
+            </Link>
+          </Button>
         </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className="p-8 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">Local Committees</h1>
-          <p className="text-muted-foreground">Manage local committees and their information</p>
-        </div>
-        <Button asChild>
+        <Button asChild className="rounded-full px-5">
           <Link href="/admin/committees/new">
-            <Plus className="w-4 h-4 mr-2" />
+            <Plus className="mr-2 h-4 w-4" />
             Add Committee
           </Link>
         </Button>
       </div>
 
       {committees.length === 0 ? (
-        <Card>
-          <CardContent className="p-8 text-center">
-            <p className="text-muted-foreground mb-4">No committees found</p>
-            <Button asChild>
+        <Card className="border-border/60 bg-card/80 shadow-sm">
+          <CardContent className="p-10 text-center">
+            <p className="mb-4 text-muted-foreground">No committees found</p>
+            <Button asChild className="rounded-full px-5">
               <Link href="/admin/committees/new">
-                <Plus className="w-4 h-4 mr-2" />
+                <Plus className="mr-2 h-4 w-4" />
                 Add First Committee
               </Link>
             </Button>
           </CardContent>
         </Card>
       ) : (
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {committees.map((committee) => (
-            <Card key={committee.id} className="group">
+            <Card
+              key={committee.id}
+              className="group border-border/60 bg-card/80 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg"
+            >
               <CardHeader className="pb-3">
                 <div className="flex items-start justify-between">
                   <div className="flex items-center space-x-3">
-                    <div className="w-12 h-12 relative rounded-lg overflow-hidden bg-muted">
+                    <div className="relative h-12 w-12 overflow-hidden rounded-xl border border-border/40 bg-background/70">
                       <Image
                         src={committee.logo_url || "/placeholder.svg?height=48&width=48"}
                         alt={`${committee.name} logo`}
@@ -135,18 +141,28 @@ export default function CommitteesAdminPage() {
 
                 <div className="flex items-center justify-between">
                   <div className="flex space-x-2">
-                    <Button variant="outline" size="sm" asChild>
+                    <Button variant="outline" size="sm" className="rounded-full" asChild>
                       <Link href={`/admin/committees/${committee.id}/edit`}>
                         <Edit className="w-4 h-4" />
                       </Link>
                     </Button>
-                    <Button variant="outline" size="sm" onClick={() => handleDelete(committee.id, committee.name)}>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="rounded-full"
+                      onClick={() => handleDelete(committee.id, committee.name)}
+                    >
                       <Trash2 className="w-4 h-4" />
                     </Button>
                   </div>
 
                   {committee.website_url && (
-                    <Button variant="ghost" size="sm" onClick={() => window.open(committee.website_url!, "_blank")}>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="rounded-full"
+                      onClick={() => window.open(committee.website_url!, "_blank")}
+                    >
                       <ExternalLink className="w-4 h-4" />
                     </Button>
                   )}
@@ -156,6 +172,29 @@ export default function CommitteesAdminPage() {
           ))}
         </div>
       )}
+    </div>
+  )
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-background via-muted/40 to-background">
+        <AdminNavigation />
+        <main className="flex min-h-[60vh] items-center justify-center pt-24">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-accent/40 border-t-accent"></div>
+            <p className="mt-4 text-sm text-muted-foreground">Loading committees...</p>
+          </div>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/40 to-background">
+      <AdminNavigation />
+      <main className="pt-24 pb-12">
+        <div className="mx-auto max-w-6xl space-y-6 px-4 sm:px-6 lg:px-8">{pageContent}</div>
+      </main>
     </div>
   )
 }

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
-import { Plus, Edit, Trash2, Calendar, MapPin } from "lucide-react"
+import { Plus, Edit, Trash2, Calendar, MapPin, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { AdminNavigation } from "@/components/admin/admin-navigation"
@@ -124,11 +124,12 @@ export default function AdminEventsPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background">
+      <div className="min-h-screen bg-gradient-to-br from-background via-muted/40 to-background">
         <AdminNavigation />
-        <main className="pt-16">
-          <div className="p-8">
-            <div className="text-center">Loading events...</div>
+        <main className="flex min-h-[60vh] items-center justify-center pt-24">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-accent/40 border-t-accent"></div>
+            <p className="mt-4 text-sm text-muted-foreground">Loading events...</p>
           </div>
         </main>
       </div>
@@ -199,7 +200,10 @@ export default function AdminEventsPage() {
       : "Date to be announced"
 
     return (
-      <Card key={`${isUpcoming ? "upcoming" : "past"}-${event.id}`}>
+      <Card
+        key={`${isUpcoming ? "upcoming" : "past"}-${event.id}`}
+        className="border-border/60 bg-card/80 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg"
+      >
         <CardContent className="p-6">
           <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div className="flex flex-1 space-x-4">
@@ -235,7 +239,7 @@ export default function AdminEventsPage() {
                     <Button
                       asChild
                       variant="outline"
-                      className="border border-input bg-white text-black hover:bg-muted"
+                      className="rounded-full border border-input bg-background text-foreground hover:bg-muted"
                     >
                       <Link
                         href={event.registration_url || "#"}
@@ -246,10 +250,7 @@ export default function AdminEventsPage() {
                       </Link>
                     </Button>
                   ) : (
-                    <Button
-                      asChild
-                      className="bg-neutral-800 text-neutral-200 hover:bg-neutral-700"
-                    >
+                    <Button asChild className="rounded-full bg-neutral-900 text-neutral-100 hover:bg-neutral-700">
                       <Link
                         href={event.registration_url || "#"}
                         target="_blank"
@@ -264,26 +265,31 @@ export default function AdminEventsPage() {
             </div>
             <div className="flex items-center justify-end space-x-2">
               {isSupabaseConfigured ? (
-                <Button variant="outline" size="sm" asChild>
+                <Button variant="outline" size="sm" className="rounded-full" asChild>
                   <Link href={`/admin/events/${event.id}/edit`}>
                     <Edit className="mr-2 h-4 w-4" />
                     Edit
                   </Link>
                 </Button>
               ) : (
-                <Button variant="outline" size="sm" onClick={showSupabaseToast}>
+                <Button variant="outline" size="sm" className="rounded-full" onClick={showSupabaseToast}>
                   <Edit className="mr-2 h-4 w-4" />
                   Edit
                 </Button>
               )}
-              <Button variant="outline" size="sm" onClick={() => toggleActive(event.id, event.is_active)}>
+              <Button
+                variant="outline"
+                size="sm"
+                className="rounded-full"
+                onClick={() => toggleActive(event.id, event.is_active)}
+              >
                 {event.is_active ? "Deactivate" : "Activate"}
               </Button>
               <Button
                 variant="outline"
                 size="sm"
+                className="rounded-full text-destructive"
                 onClick={() => handleDelete(event.id)}
-                className="text-destructive hover:text-destructive"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>
@@ -295,32 +301,45 @@ export default function AdminEventsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/40 to-background">
       <AdminNavigation />
-      <main className="pt-16">
-        <div className="p-8">
-          <div className="flex justify-between items-center mb-8">
-            <div>
-              <h1 className="text-3xl font-bold text-foreground">Events Management</h1>
-              <p className="text-muted-foreground">Manage upcoming events and activities</p>
+      <main className="pt-24 pb-12">
+        <div className="mx-auto max-w-6xl space-y-8 px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-3">
+              <div>
+                <h1 className="text-3xl font-semibold text-foreground">Events Management</h1>
+                <p className="text-muted-foreground">Manage upcoming events and activities</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                asChild
+                className="w-full justify-start rounded-full text-muted-foreground transition hover:text-foreground md:w-auto"
+              >
+                <Link href="/admin">
+                  <ArrowLeft className="mr-2 h-4 w-4" />
+                  Back to dashboard
+                </Link>
+              </Button>
             </div>
             {isSupabaseConfigured ? (
-              <Button asChild>
+              <Button asChild className="rounded-full px-5">
                 <Link href="/admin/events/new">
-                  <Plus className="w-4 h-4 mr-2" />
+                  <Plus className="mr-2 h-4 w-4" />
                   Add New Event
                 </Link>
               </Button>
             ) : (
-              <Button onClick={showSupabaseToast} variant="outline">
-                <Plus className="w-4 h-4 mr-2" />
+              <Button onClick={showSupabaseToast} variant="outline" className="rounded-full px-5">
+                <Plus className="mr-2 h-4 w-4" />
                 Add New Event
               </Button>
             )}
           </div>
 
           {!isSupabaseConfigured && (
-            <Alert variant="destructive" className="mb-6">
+            <Alert variant="destructive" className="border border-border/60 bg-destructive/10 text-destructive">
               <AlertTitle>Event management is read-only</AlertTitle>
               <AlertDescription>
                 Supabase credentials are not configured. Existing entries shown here are static fallback data and cannot be
@@ -331,21 +350,21 @@ export default function AdminEventsPage() {
 
           <div className="grid gap-10">
             {events.length === 0 ? (
-              <Card>
-                <CardContent className="p-8 text-center">
-                  <Calendar className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
-                  <h3 className="text-lg font-medium mb-2">No events found</h3>
-                  <p className="text-muted-foreground mb-4">Get started by creating your first event.</p>
+              <Card className="border-border/60 bg-card/80 shadow-sm">
+                <CardContent className="p-10 text-center">
+                  <Calendar className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+                  <h3 className="mb-2 text-lg font-medium">No events found</h3>
+                  <p className="mb-4 text-muted-foreground">Get started by creating your first event.</p>
                   {isSupabaseConfigured ? (
-                    <Button asChild>
+                    <Button asChild className="rounded-full px-5">
                       <Link href="/admin/events/new">
-                        <Plus className="w-4 h-4 mr-2" />
+                        <Plus className="mr-2 h-4 w-4" />
                         Create First Event
                       </Link>
                     </Button>
                   ) : (
-                    <Button onClick={showSupabaseToast} variant="outline">
-                      <Plus className="w-4 h-4 mr-2" />
+                    <Button onClick={showSupabaseToast} variant="outline" className="rounded-full px-5">
+                      <Plus className="mr-2 h-4 w-4" />
                       Create First Event
                     </Button>
                   )}
@@ -360,7 +379,7 @@ export default function AdminEventsPage() {
                   </div>
                   <div className="mt-4 grid gap-6">
                     {upcomingEvents.length === 0 ? (
-                      <Card>
+                      <Card className="border-border/60 bg-card/60">
                         <CardContent className="p-6 text-center text-sm text-muted-foreground">
                           No upcoming events.
                         </CardContent>
@@ -377,7 +396,7 @@ export default function AdminEventsPage() {
                   </div>
                   <div className="mt-4 grid gap-6">
                     {pastEvents.length === 0 ? (
-                      <Card>
+                      <Card className="border-border/60 bg-card/60">
                         <CardContent className="p-6 text-center text-sm text-muted-foreground">
                           No past events yet.
                         </CardContent>

--- a/app/admin/magazine/page.tsx
+++ b/app/admin/magazine/page.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { Card, CardContent } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowLeft, Edit, Eye, FileText, Plus, Trash2 } from "lucide-react"
+
+import { AdminNavigation } from "@/components/admin/admin-navigation"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
-import { Plus, Edit, Trash2, Eye, FileText } from "lucide-react"
-import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 
@@ -123,141 +125,171 @@ export default function AdminMagazinePage() {
 
   if (loading) {
     return (
-      <div className="p-8">
-        <div className="text-center">Loading magazine issues...</div>
+      <div className="min-h-screen bg-gradient-to-br from-background via-muted/40 to-background">
+        <AdminNavigation />
+        <main className="flex min-h-[60vh] items-center justify-center pt-24">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-accent/40 border-t-accent"></div>
+            <p className="mt-4 text-sm text-muted-foreground">Loading magazine issues...</p>
+          </div>
+        </main>
       </div>
     )
   }
 
   return (
-    <div className="p-8">
-      <div className="flex justify-between items-center mb-8">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">Magazine Management</h1>
-          <p className="text-muted-foreground">Manage magazine issues and publications</p>
-        </div>
-        {isSupabaseConfigured ? (
-          <Button asChild>
-            <Link href="/admin/magazine/new">
-              <Plus className="w-4 h-4 mr-2" />
-              Add New Issue
-            </Link>
-          </Button>
-        ) : (
-          <Button onClick={showSupabaseToast} variant="outline">
-            <Plus className="w-4 h-4 mr-2" />
-            Add New Issue
-          </Button>
-        )}
-      </div>
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/40 to-background">
+      <AdminNavigation />
+      <main className="pt-24 pb-12">
+        <div className="mx-auto max-w-6xl space-y-8 px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-3">
+              <div>
+                <h1 className="text-3xl font-semibold text-foreground">Magazine Management</h1>
+                <p className="text-muted-foreground">Manage magazine issues and publications</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                asChild
+                className="w-full justify-start rounded-full text-muted-foreground transition hover:text-foreground md:w-auto"
+              >
+                <Link href="/admin">
+                  <ArrowLeft className="mr-2 h-4 w-4" />
+                  Back to dashboard
+                </Link>
+              </Button>
+            </div>
+            {isSupabaseConfigured ? (
+              <Button asChild className="rounded-full px-5">
+                <Link href="/admin/magazine/new">
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add New Issue
+                </Link>
+              </Button>
+            ) : (
+              <Button onClick={showSupabaseToast} variant="outline" className="rounded-full px-5">
+                <Plus className="mr-2 h-4 w-4" />
+                Add New Issue
+              </Button>
+            )}
+          </div>
 
-      {!isSupabaseConfigured && (
-        <Alert variant="destructive" className="mb-6">
-          <AlertTitle>Magazine management is read-only</AlertTitle>
-          <AlertDescription>
-            Supabase credentials are not configured. The issues listed below are static fallback data and cannot be changed until
-            Supabase is connected.
-          </AlertDescription>
-        </Alert>
-      )}
+          {!isSupabaseConfigured && (
+            <Alert variant="destructive" className="border border-border/60 bg-destructive/10 text-destructive">
+              <AlertTitle>Magazine management is read-only</AlertTitle>
+              <AlertDescription>
+                Supabase credentials are not configured. The issues listed below are static fallback data and cannot be changed
+                until Supabase is connected.
+              </AlertDescription>
+            </Alert>
+          )}
 
-      <div className="grid gap-6">
-        {issues.length === 0 ? (
-          <Card>
-            <CardContent className="p-8 text-center">
-              <FileText className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
-              <h3 className="text-lg font-medium mb-2">No magazine issues found</h3>
-              <p className="text-muted-foreground mb-4">Get started by creating your first magazine issue.</p>
-              {isSupabaseConfigured ? (
-                <Button asChild>
-                  <Link href="/admin/magazine/new">
-                    <Plus className="w-4 h-4 mr-2" />
-                    Create First Issue
-                  </Link>
-                </Button>
-              ) : (
-                <Button onClick={showSupabaseToast} variant="outline">
-                  <Plus className="w-4 h-4 mr-2" />
-                  Create First Issue
-                </Button>
-              )}
-            </CardContent>
-          </Card>
-        ) : (
-          issues.map((issue) => (
-            <Card key={issue.id}>
-              <CardContent className="p-6">
-                <div className="flex items-start justify-between">
-                  <div className="flex space-x-4">
-                    {issue.cover_image_url && (
-                      <img
-                        src={issue.cover_image_url || "/placeholder.svg"}
-                        alt={`${issue.title} cover`}
-                        className="w-16 h-20 object-cover rounded"
-                      />
-                    )}
-                    <div className="flex-1">
-                      <div className="flex flex-wrap items-center gap-2 mb-2">
-                        <h3 className="text-lg font-semibold text-foreground">{issue.title}</h3>
-                        <Badge variant={issue.is_active ? "default" : "secondary"}>
-                          {issue.is_active ? "Active" : "Inactive"}
-                        </Badge>
-                        <Badge variant="outline" className="capitalize">
-                          {issue.publication_type}
-                        </Badge>
-                        {issue.is_featured && <Badge variant="outline">Featured</Badge>}
+          <div className="grid gap-6 lg:grid-cols-2">
+            {issues.length === 0 ? (
+              <Card className="border-border/60 bg-card/80 shadow-sm">
+                <CardContent className="p-10 text-center">
+                  <FileText className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+                  <h3 className="mb-2 text-lg font-medium">No magazine issues found</h3>
+                  <p className="mb-4 text-muted-foreground">Get started by creating your first magazine issue.</p>
+                  {isSupabaseConfigured ? (
+                    <Button asChild className="rounded-full px-5">
+                      <Link href="/admin/magazine/new">
+                        <Plus className="mr-2 h-4 w-4" />
+                        Create First Issue
+                      </Link>
+                    </Button>
+                  ) : (
+                    <Button onClick={showSupabaseToast} variant="outline" className="rounded-full px-5">
+                      <Plus className="mr-2 h-4 w-4" />
+                      Create First Issue
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            ) : (
+              issues.map((issue) => (
+                <Card
+                  key={issue.id}
+                  className="border-border/60 bg-card/80 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg"
+                >
+                  <CardContent className="space-y-4 p-6">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="flex flex-1 space-x-4">
+                        {issue.cover_image_url && (
+                          <img
+                            src={issue.cover_image_url || "/placeholder.svg"}
+                            alt={`${issue.title} cover`}
+                            className="hidden h-24 w-20 rounded-xl object-cover sm:block"
+                          />
+                        )}
+                        <div className="flex-1 space-y-3">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="text-lg font-semibold text-foreground">{issue.title}</h3>
+                            <Badge variant={issue.is_active ? "default" : "secondary"} className="rounded-full">
+                              {issue.is_active ? "Active" : "Inactive"}
+                            </Badge>
+                            <Badge variant="outline" className="capitalize">
+                              {issue.publication_type}
+                            </Badge>
+                            {issue.is_featured && <Badge variant="outline">Featured</Badge>}
+                          </div>
+                          <div className="grid gap-1 text-sm text-muted-foreground">
+                            {issue.description && <p>{issue.description}</p>}
+                            <p>
+                              Issue No. {issue.issue_number || "Not set"} · Published: {" "}
+                              {issue.publication_date ? new Date(issue.publication_date).toLocaleDateString() : "TBA"}
+                            </p>
+                          </div>
+                        </div>
                       </div>
-                      <p className="text-sm text-muted-foreground mb-2">
-                        {issue.issue_number ? issue.issue_number : "Issue number not set"}
-                      </p>
-                      {issue.description && (
-                        <p className="text-sm text-muted-foreground mb-2">{issue.description}</p>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        Published: {issue.publication_date ? new Date(issue.publication_date).toLocaleDateString() : "Not scheduled"}
-                      </p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        {issue.pdf_url && (
+                          <Button variant="outline" size="sm" className="rounded-full" asChild>
+                            <Link href={issue.pdf_url} target="_blank" rel="noopener noreferrer">
+                              <Eye className="mr-2 h-4 w-4" />
+                              View PDF
+                            </Link>
+                          </Button>
+                        )}
+                        {isSupabaseConfigured ? (
+                          <Button variant="outline" size="sm" className="rounded-full" asChild>
+                            <Link href={`/admin/magazine/${issue.id}/edit`}>
+                              <Edit className="mr-2 h-4 w-4" />
+                              Edit
+                            </Link>
+                          </Button>
+                        ) : (
+                          <Button variant="outline" size="sm" className="rounded-full" onClick={showSupabaseToast}>
+                            <Edit className="mr-2 h-4 w-4" />
+                            Edit
+                          </Button>
+                        )}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="rounded-full"
+                          onClick={() => toggleActive(issue.id, issue.is_active)}
+                        >
+                          {issue.is_active ? "Deactivate" : "Activate"}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="rounded-full text-destructive"
+                          onClick={() => handleDelete(issue.id)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
                     </div>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    {issue.pdf_url && (
-                      <Button variant="outline" size="sm" asChild>
-                        <a href={issue.pdf_url} target="_blank" rel="noopener noreferrer">
-                          <Eye className="w-4 h-4 mr-2" />
-                          View PDF
-                        </a>
-                      </Button>
-                    )}
-                    {isSupabaseConfigured ? (
-                      <Button variant="outline" size="sm" asChild>
-                        <Link href={`/admin/magazine/${issue.id}/edit`}>
-                          <Edit className="w-4 h-4 mr-2" />
-                          Edit
-                        </Link>
-                      </Button>
-                    ) : (
-                      <Button variant="outline" size="sm" onClick={showSupabaseToast}>
-                        <Edit className="w-4 h-4 mr-2" />
-                        Edit
-                      </Button>
-                    )}
-                    <Button variant="outline" size="sm" onClick={() => toggleActive(issue.id, issue.is_active)}>
-                      {issue.is_active ? "Deactivate" : "Activate"}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleDelete(issue.id)}
-                      className="text-destructive hover:text-destructive"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))
-        )}
-      </div>
+                  </CardContent>
+                </Card>
+              ))
+            )}
+          </div>
+        </div>
+      </main>
     </div>
   )
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,10 +4,18 @@ import { AdminNavigation } from "@/components/admin/admin-navigation"
 
 export default function AdminPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/40 to-background">
       <AdminNavigation />
-      <main className="pt-16">
-        <Suspense fallback={<div className="p-8">Loading...</div>}>
+      <main className="pt-24 pb-12">
+        <Suspense
+          fallback={
+            <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+              <div className="rounded-3xl border border-border/60 bg-card/60 p-8 text-center text-muted-foreground shadow-sm">
+                Loading...
+              </div>
+            </div>
+          }
+        >
           <AdminDashboard />
         </Suspense>
       </main>

--- a/components/admin/admin-dashboard.tsx
+++ b/components/admin/admin-dashboard.tsx
@@ -91,37 +91,47 @@ export function AdminDashboard() {
   ]
 
   return (
-    <div className="p-8 space-y-8">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">Admin Dashboard</h1>
-          <p className="text-muted-foreground">Manage your IACES website content</p>
+    <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
+      <div className="overflow-hidden rounded-3xl border border-border/60 bg-card/80 shadow-sm backdrop-blur">
+        <div className="flex flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">Dashboard</p>
+            <h1 className="text-3xl font-bold text-foreground sm:text-4xl">Welcome back to the Admin Hub</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Monitor high-level activity, jump into key management areas, and keep your IACES presence looking fresh.
+            </p>
+          </div>
+          <Button asChild className="rounded-full px-6 py-2 text-sm shadow">
+            <Link href="/">
+              <Eye className="mr-2 h-4 w-4" />
+              View live site
+            </Link>
+          </Button>
         </div>
-        <Button asChild>
-          <Link href="/">
-            <Eye className="w-4 h-4 mr-2" />
-            View Site
-          </Link>
-        </Button>
       </div>
 
       {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
         {stats.map((stat, index) => {
           const Icon = stat.icon
           return (
-            <Card key={index}>
+            <Card
+              key={index}
+              className="border-border/60 bg-gradient-to-br from-background via-card to-card/80 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg"
+            >
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-muted-foreground">{stat.title}</CardTitle>
-                <Icon className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm font-medium text-muted-foreground/80">{stat.title}</CardTitle>
+                <span className="rounded-full border border-border/60 bg-background/80 p-2">
+                  <Icon className="h-4 w-4 text-accent" />
+                </span>
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold text-foreground">{stat.value}</div>
-                <div className="flex items-center space-x-1 text-xs">
+                <div className="text-3xl font-semibold text-foreground">{stat.value}</div>
+                <div className="mt-2 flex items-center space-x-2 text-xs">
                   <Badge variant={stat.changeType === "positive" ? "default" : "secondary"} className="text-xs">
                     {stat.change}
                   </Badge>
-                  <span className="text-muted-foreground">from last month</span>
+                  <span className="text-muted-foreground">vs. last month</span>
                 </div>
               </CardContent>
             </Card>
@@ -129,31 +139,36 @@ export function AdminDashboard() {
         })}
       </div>
 
-      <div className="grid lg:grid-cols-2 gap-8">
+      <div className="grid gap-8 lg:grid-cols-2">
         {/* Quick Actions */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <Plus className="w-5 h-5" />
+        <Card className="border-border/60 bg-card/80 shadow-sm">
+          <CardHeader className="border-b border-border/40 pb-4">
+            <CardTitle className="flex items-center space-x-2 text-lg">
+              <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-accent/10">
+                <Plus className="h-5 w-5 text-accent" />
+              </span>
               <span>Quick Actions</span>
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-3 pt-4">
             {quickActions.map((action, index) => {
               const Icon = action.icon
               return (
-                <div key={index} className="flex items-center justify-between p-4 border border-border rounded-lg">
+                <div
+                  key={index}
+                  className="flex items-center justify-between rounded-2xl border border-border/50 bg-background/60 p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-accent/60 hover:shadow-md"
+                >
                   <div className="flex items-center space-x-3">
-                    <div className="p-2 bg-accent/20 rounded-lg">
-                      <Icon className="w-4 h-4 text-accent-foreground" />
+                    <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-accent/10">
+                      <Icon className="h-5 w-5 text-accent" />
                     </div>
                     <div>
                       <h4 className="font-medium text-foreground">{action.title}</h4>
                       <p className="text-sm text-muted-foreground">{action.description}</p>
                     </div>
                   </div>
-                  <Button variant="outline" size="sm" asChild>
-                    <Link href={action.href}>Go</Link>
+                  <Button variant="outline" size="sm" className="rounded-full" asChild>
+                    <Link href={action.href}>Open</Link>
                   </Button>
                 </div>
               )
@@ -162,23 +177,28 @@ export function AdminDashboard() {
         </Card>
 
         {/* Recent Activity */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <TrendingUp className="w-5 h-5" />
+        <Card className="border-border/60 bg-card/80 shadow-sm">
+          <CardHeader className="border-b border-border/40 pb-4">
+            <CardTitle className="flex items-center space-x-2 text-lg">
+              <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-accent/10">
+                <TrendingUp className="h-5 w-5 text-accent" />
+              </span>
               <span>Recent Activity</span>
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-4 pt-4">
             {recentActivity.map((activity, index) => (
-              <div key={index} className="flex items-start space-x-3 p-3 border border-border rounded-lg">
-                <div className="w-2 h-2 bg-accent rounded-full mt-2"></div>
+              <div
+                key={index}
+                className="flex items-start space-x-3 rounded-2xl border border-border/50 bg-background/60 p-4 shadow-sm"
+              >
+                <div className="mt-2 h-2 w-2 rounded-full bg-accent"></div>
                 <div className="flex-1">
                   <p className="text-sm font-medium text-foreground">{activity.action}</p>
                   <p className="text-sm text-muted-foreground">{activity.item}</p>
-                  <p className="text-xs text-muted-foreground mt-1">{activity.time}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{activity.time}</p>
                 </div>
-                <Badge variant="outline" className="text-xs">
+                <Badge variant="outline" className="rounded-full text-xs capitalize">
                   {activity.type}
                 </Badge>
               </div>
@@ -188,96 +208,71 @@ export function AdminDashboard() {
       </div>
 
       {/* Content Management Overview */}
-      <div className="grid md:grid-cols-2 lg:grid-cols-6 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Hero Section</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">Manage the main homepage hero content and call-to-action.</p>
-            <Button variant="outline" size="sm" asChild className="w-full bg-transparent">
-              <Link href="/admin/hero">
-                <Edit className="w-4 h-4 mr-2" />
-                Edit Hero
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">About Section</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">Update mission, vision, and organizational information.</p>
-            <Button variant="outline" size="sm" asChild className="w-full bg-transparent">
-              <Link href="/admin/about">
-                <Edit className="w-4 h-4 mr-2" />
-                Edit About
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Board Members</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">Manage board member profiles and information.</p>
-            <Button variant="outline" size="sm" asChild className="w-full bg-transparent">
-              <Link href="/admin/board">
-                <Users className="w-4 h-4 mr-2" />
-                Manage Board
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Local Committees</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">Manage local committees and their information.</p>
-            <Button variant="outline" size="sm" asChild className="w-full bg-transparent">
-              <Link href="/admin/committees">
-                <Globe className="w-4 h-4 mr-2" />
-                Manage Committees
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Publications</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">Manage magazines and newsletters.</p>
-            <Button variant="outline" size="sm" asChild className="w-full bg-transparent">
-              <Link href="/admin/magazine">
-                <FileText className="w-4 h-4 mr-2" />
-                Manage Publications
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Events</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">Manage upcoming and past events.</p>
-            <Button variant="outline" size="sm" asChild className="w-full bg-transparent">
-              <Link href="/admin/events">
-                <Calendar className="w-4 h-4 mr-2" />
-                Manage Events
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {[
+          {
+            title: "Hero Section",
+            description: "Manage the main homepage hero content and call-to-action.",
+            href: "/admin/hero",
+            icon: <Edit className="h-4 w-4" />,
+            cta: "Edit Hero",
+          },
+          {
+            title: "About Section",
+            description: "Update mission, vision, and organizational information.",
+            href: "/admin/about",
+            icon: <Edit className="h-4 w-4" />,
+            cta: "Edit About",
+          },
+          {
+            title: "Board Members",
+            description: "Manage board member profiles and information.",
+            href: "/admin/board",
+            icon: <Users className="h-4 w-4" />,
+            cta: "Manage Board",
+          },
+          {
+            title: "Local Committees",
+            description: "Manage local committees and their information.",
+            href: "/admin/committees",
+            icon: <Globe className="h-4 w-4" />,
+            cta: "Manage Committees",
+          },
+          {
+            title: "Publications",
+            description: "Manage magazines and newsletters.",
+            href: "/admin/magazine",
+            icon: <FileText className="h-4 w-4" />,
+            cta: "Manage Publications",
+          },
+          {
+            title: "Events",
+            description: "Manage upcoming and past events.",
+            href: "/admin/events",
+            icon: <Calendar className="h-4 w-4" />,
+            cta: "Manage Events",
+          },
+        ].map((section) => (
+          <Card
+            key={section.title}
+            className="flex h-full flex-col justify-between border-border/60 bg-card/80 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg"
+          >
+            <CardHeader className="border-b border-border/40 pb-4">
+              <CardTitle className="text-lg text-foreground">{section.title}</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col justify-between space-y-4 pt-4">
+              <p className="text-sm text-muted-foreground">{section.description}</p>
+              <Button variant="outline" size="sm" asChild className="w-full rounded-full">
+                <Link href={section.href}>
+                  <span className="mr-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-accent/10 text-accent">
+                    {section.icon}
+                  </span>
+                  {section.cta}
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
       </div>
     </div>
   )

--- a/components/admin/admin-navigation.tsx
+++ b/components/admin/admin-navigation.tsx
@@ -2,12 +2,16 @@
 
 import { useState } from "react"
 import Link from "next/link"
+import Image from "next/image"
+import { usePathname } from "next/navigation"
+import clsx from "clsx"
 import { Button } from "@/components/ui/button"
 import { UserMenu } from "@/components/auth/user-menu"
 import { Menu, X, Home, Settings, Users, FileText, Calendar, Mail, BarChart3 } from "lucide-react"
 
 export function AdminNavigation() {
   const [isOpen, setIsOpen] = useState(false)
+  const pathname = usePathname()
 
   const navItems = [
     { href: "/admin", icon: BarChart3, label: "Dashboard" },
@@ -21,27 +25,39 @@ export function AdminNavigation() {
   ]
 
   return (
-    <nav className="fixed top-0 w-full z-50 bg-card border-b border-border">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
-          <div className="flex items-center">
-            <Link href="/admin" className="text-xl font-bold text-foreground">
-              IACES Admin
-            </Link>
-          </div>
+    <nav className="fixed top-0 z-50 w-full border-b border-border/60 bg-card/80 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/70">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-20 items-center justify-between">
+          <Link href="/admin" className="group flex items-center space-x-3">
+            <span className="relative block h-11 w-11 overflow-hidden rounded-full border border-border/60 bg-background/60 p-2 shadow-sm transition-transform duration-200 group-hover:scale-105">
+              <Image src="/iaces-logo.png" alt="IACES" fill className="object-contain" priority />
+            </span>
+            <span className="hidden flex-col text-sm font-semibold leading-tight text-muted-foreground sm:flex">
+              <span className="text-xs font-medium uppercase tracking-widest text-accent">IACES</span>
+              <span className="text-base text-foreground">Admin Hub</span>
+            </span>
+            <span className="sr-only">IACES Admin</span>
+          </Link>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:block">
-            <div className="ml-10 flex items-baseline space-x-4">
+          <div className="hidden items-center justify-center md:flex">
+            <div className="flex items-center space-x-2 rounded-full border border-border/50 bg-background/80 p-1 shadow-inner">
               {navItems.map((item) => {
                 const Icon = item.icon
+                const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`)
+
                 return (
                   <Link
                     key={item.href}
                     href={item.href}
-                    className="flex items-center space-x-1 text-muted-foreground hover:text-foreground transition-colors px-3 py-2 rounded-md text-sm"
+                    className={clsx(
+                      "flex items-center space-x-2 rounded-full px-4 py-2 text-sm font-medium transition-all",
+                      isActive
+                        ? "bg-accent text-accent-foreground shadow"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    )}
                   >
-                    <Icon className="w-4 h-4" />
+                    <Icon className="h-4 w-4" />
                     <span>{item.label}</span>
                   </Link>
                 )
@@ -49,8 +65,8 @@ export function AdminNavigation() {
             </div>
           </div>
 
-          <div className="hidden md:flex items-center space-x-2">
-            <Button variant="outline" asChild>
+          <div className="hidden items-center space-x-2 md:flex">
+            <Button variant="outline" className="rounded-full" asChild>
               <Link href="/">View Site</Link>
             </Button>
             <UserMenu />
@@ -67,23 +83,32 @@ export function AdminNavigation() {
         {/* Mobile Navigation */}
         {isOpen && (
           <div className="md:hidden">
-            <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-card border border-border rounded-lg mt-2">
+            <div className="mt-3 space-y-2 rounded-2xl border border-border/60 bg-card/95 p-3 shadow-lg">
               {navItems.map((item) => {
                 const Icon = item.icon
+                const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`)
+
                 return (
                   <Link
                     key={item.href}
                     href={item.href}
-                    className="flex items-center space-x-2 px-3 py-2 text-muted-foreground hover:text-foreground transition-colors"
+                    className={clsx(
+                      "flex items-center space-x-3 rounded-xl px-3 py-2 text-sm font-medium transition",
+                      isActive
+                        ? "bg-accent/10 text-accent-foreground"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    )}
                     onClick={() => setIsOpen(false)}
                   >
-                    <Icon className="w-4 h-4" />
+                    <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-background/80 shadow-inner">
+                      <Icon className="h-4 w-4" />
+                    </span>
                     <span>{item.label}</span>
                   </Link>
                 )
               })}
-              <div className="flex items-center space-x-2 px-3 py-2">
-                <Button variant="outline" size="sm" asChild>
+              <div className="flex items-center justify-between space-x-2 rounded-xl bg-background/80 p-2">
+                <Button variant="outline" size="sm" className="flex-1 rounded-full" asChild>
                   <Link href="/">View Site</Link>
                 </Button>
                 <UserMenu />


### PR DESCRIPTION
## Summary
- replace the textual IACES heading with the official logo and modernize the admin navigation styling
- restyle the admin dashboard cards and background for a cohesive visual refresh
- add consistent navigation/back buttons and layout polish to the committees, magazine, and events admin sections

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d586c0e980832f8ee92f83909a44cd