### PR TITLE
Optimize homepage data fetching

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,49 +1,16 @@
 import Link from "next/link"
-import { headers } from "next/headers"
 import { Calendar, Clock, MapPin } from "lucide-react"
 
-import { Navigation } from "@/components/navigation"
 import { Footer } from "@/components/footer"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
+import { Navigation } from "@/components/navigation"
 import { Badge } from "@/components/ui/badge"
-import { fallbackEvents } from "@/lib/fallback-data"
-import type { EventItem } from "@/lib/types"
-import { formatEventDate, isExternalUrl, splitEventsByTime, toEventItem } from "@/lib/event-utils"
-
-async function fetchEvents(): Promise<EventItem[]> {
-  const fallback = fallbackEvents.map(toEventItem)
-
-  try {
-    const headerList = headers()
-    const host = headerList.get("host")
-
-    if (!host) {
-      return fallback
-    }
-
-    const protocol = host.startsWith("localhost") || host.startsWith("127.") ? "http" : "https"
-    const response = await fetch(`${protocol}://${host}/api/events`, { cache: "no-store" })
-
-    if (!response.ok) {
-      return fallback
-    }
-
-    const data = await response.json()
-    if (!Array.isArray(data)) {
-      return fallback
-    }
-
-    const events = data.map(toEventItem)
-    return events.length > 0 ? events : fallback
-  } catch (error) {
-    console.error("Error loading events page data:", error)
-    return fallback
-  }
-}
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getEvents } from "@/lib/data/events"
+import { formatEventDate, isExternalUrl, splitEventsByTime } from "@/lib/event-utils"
 
 export default async function EventsPage() {
-  const events = await fetchEvents()
+  const events = await getEvents()
   const { upcoming, past } = splitEventsByTime(events)
   const hasEvents = upcoming.length > 0 || past.length > 0
   const isFallbackData = events.length > 0 && events.every((event) => event.id.startsWith("fallback-"))

--- a/components/dynamic-hero-section.tsx
+++ b/components/dynamic-hero-section.tsx
@@ -1,44 +1,21 @@
-"use client"
-
-import { useEffect, useState } from "react"
-import { Button } from "@/components/ui/button"
 import Link from "next/link"
+
+import { Button } from "@/components/ui/button"
+import { ContentService } from "@/lib/content-service"
 import type { HeroContent } from "@/lib/types"
 
-export function DynamicHeroSection() {
-  const [heroContent, setHeroContent] = useState<HeroContent | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const fetchHeroContent = async () => {
-      try {
-        const response = await fetch("/api/hero")
-        if (response.ok) {
-          const data = await response.json()
-          setHeroContent(data)
-        }
-      } catch (error) {
-        console.error("Error fetching hero content:", error)
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchHeroContent()
-  }, [])
-
-  if (loading) {
-    return (
-      <section className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-secondary/20">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent mx-auto"></div>
-          <p className="text-muted-foreground mt-4">Loading...</p>
-        </div>
-      </section>
-    )
+async function getHeroContent(): Promise<HeroContent | null> {
+  try {
+    return await ContentService.getActiveHeroContent()
+  } catch (error) {
+    console.error("Error loading hero content:", error)
+    return null
   }
+}
 
-  const content = heroContent || {
+export async function DynamicHeroSection() {
+  const heroContent = await getHeroContent()
+  const content = heroContent ?? {
     title: "International Association of Civil Engineering Students",
     subtitle: "Connecting Future Engineers Worldwide",
     description:

--- a/lib/data/events.ts
+++ b/lib/data/events.ts
@@ -1,0 +1,34 @@
+import { fallbackEvents } from "@/lib/fallback-data"
+import { toEventItem } from "@/lib/event-utils"
+import { createClient, createServiceRoleClient, isSupabaseConfigured } from "@/lib/supabase/server"
+import type { EventItem } from "@/lib/types"
+
+export async function getEvents(): Promise<EventItem[]> {
+  const fallback = fallbackEvents.map(toEventItem)
+
+  if (!isSupabaseConfigured()) {
+    return fallback
+  }
+
+  try {
+    const supabase = await createClient()
+    const queryClient = createServiceRoleClient() ?? supabase
+
+    let { data, error } = await queryClient.from("events").select("*").order("event_date", { ascending: true })
+
+    if (error?.message?.toLowerCase().includes("event_date")) {
+      ;({ data, error } = await queryClient.from("events").select("*").order("date", { ascending: true }))
+    }
+
+    if (error) {
+      console.error("Error loading events from Supabase:", error)
+      return fallback
+    }
+
+    const events = (data ?? []).map(toEventItem)
+    return events.length > 0 ? events : fallback
+  } catch (error) {
+    console.error("Error loading events data:", error)
+    return fallback
+  }
+}


### PR DESCRIPTION
## Summary
- convert the homepage hero and events sections to server components so they render with Supabase content without client-side spinners
- add a shared events data loader and reuse it on the events page for consistent fallbacks and server-side rendering

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d58f6159c8832f89e13ad958361198