### PR TITLE
Remove phone, office hours, and GitHub references

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -10,13 +10,10 @@ export default function SettingsAdminPage() {
     siteTitle: "IACES - International Association of Computer Engineering Students",
     siteDescription: "Connecting computer engineering students worldwide",
     contactEmail: "info@iaces.network",
-    contactPhone: "+1 (555) 123-4567",
     address: "123 Technology Drive, Innovation City, IC 12345",
-    officeHours: "Monday - Friday: 9:00 AM - 5:00 PM EST",
     socialFacebook: "https://facebook.com/iaces",
     socialTwitter: "https://twitter.com/iaces",
     socialLinkedin: "https://linkedin.com/company/iaces",
-    socialGithub: "https://github.com/iaces",
     maintenanceMode: false,
     allowRegistrations: true,
     enableAnalytics: true,
@@ -94,14 +91,6 @@ export default function SettingsAdminPage() {
               description="Primary contact email address"
             />
 
-            <TextField
-              label="Contact Phone"
-              value={siteSettings.contactPhone}
-              onChange={(value) => setSiteSettings((prev) => ({ ...prev, contactPhone: value }))}
-              placeholder="+1 (555) 123-4567"
-              description="Primary contact phone number"
-            />
-
             <div className="md:col-span-2">
               <TextAreaField
                 label="Address"
@@ -110,16 +99,6 @@ export default function SettingsAdminPage() {
                 placeholder="Enter full address"
                 description="Physical address of the organization"
                 rows={2}
-              />
-            </div>
-
-            <div className="md:col-span-2">
-              <TextField
-                label="Office Hours"
-                value={siteSettings.officeHours}
-                onChange={(value) => setSiteSettings((prev) => ({ ...prev, officeHours: value }))}
-                placeholder="Monday - Friday: 9:00 AM - 5:00 PM EST"
-                description="Business hours for contact"
               />
             </div>
           </div>
@@ -153,14 +132,6 @@ export default function SettingsAdminPage() {
               onChange={(value) => setSiteSettings((prev) => ({ ...prev, socialLinkedin: value }))}
               placeholder="https://linkedin.com/company/yourcompany"
               description="Link to LinkedIn company page"
-            />
-
-            <TextField
-              label="GitHub URL"
-              value={siteSettings.socialGithub}
-              onChange={(value) => setSiteSettings((prev) => ({ ...prev, socialGithub: value }))}
-              placeholder="https://github.com/yourorg"
-              description="Link to GitHub organization"
             />
           </div>
         </div>

--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
-import { Mail, Phone, MapPin, Clock } from "lucide-react"
+import { Mail, MapPin } from "lucide-react"
 
 export function ContactSection() {
   const [formData, setFormData] = useState({
@@ -61,26 +61,10 @@ export function ContactSection() {
                 </div>
 
                 <div className="flex items-start space-x-3">
-                  <Phone className="w-5 h-5 text-accent mt-0.5" />
-                  <div>
-                    <p className="font-medium text-foreground">Phone</p>
-                    <p className="text-muted-foreground text-sm">+1 (555) 123-4567</p>
-                  </div>
-                </div>
-
-                <div className="flex items-start space-x-3">
                   <Mail className="w-5 h-5 text-accent mt-0.5" />
                   <div>
                     <p className="font-medium text-foreground">Email</p>
                     <p className="text-muted-foreground text-sm">info@iaces.network</p>
-                  </div>
-                </div>
-
-                <div className="flex items-start space-x-3">
-                  <Clock className="w-5 h-5 text-accent mt-0.5" />
-                  <div>
-                    <p className="font-medium text-foreground">Office Hours</p>
-                    <p className="text-muted-foreground text-sm">Monday - Friday: 9:00 AM - 5:00 PM EST</p>
                   </div>
                 </div>
               </CardContent>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { Github, Linkedin, Twitter, Mail } from "lucide-react"
+import { Linkedin, Twitter, Mail } from "lucide-react"
 
 export function Footer() {
   return (
@@ -17,9 +17,6 @@ export function Footer() {
               </Link>
               <Link href="#" className="text-primary-foreground/80 hover:text-primary-foreground">
                 <Linkedin className="w-5 h-5" />
-              </Link>
-              <Link href="#" className="text-primary-foreground/80 hover:text-primary-foreground">
-                <Github className="w-5 h-5" />
               </Link>
               <Link href="#" className="text-primary-foreground/80 hover:text-primary-foreground">
                 <Mail className="w-5 h-5" />
@@ -68,7 +65,6 @@ export function Footer() {
             <div className="space-y-2 text-sm text-primary-foreground/80">
               <p>123 Technology Drive</p>
               <p>Innovation City, IC 12345</p>
-              <p>+1 (555) 123-4567</p>
               <p>info@iaces.network</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove phone number and office hours from the public contact section
- strip phone, office hours, and GitHub fields from the admin settings form
- drop the GitHub social icon and phone number from the footer contact block

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5be4dc2f4832f81724f02dbf29b9d