### PR TITLE
Normalize Google Drive image URLs in admin forms

### DIFF
--- a/app/admin/about/page.tsx
+++ b/app/admin/about/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/components/admin/content-editor"
 import { useToast } from "@/hooks/use-toast"
 import type { AboutContent } from "@/lib/types"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 export default function AboutAdminPage() {
   const [aboutData, setAboutData] = useState<Partial<AboutContent>>({
@@ -47,12 +48,17 @@ export default function AboutAdminPage() {
   const handleSave = async () => {
     setSaving(true)
     try {
+      const payload = {
+        ...aboutData,
+        image_url: toGoogleDriveDirectUrl(aboutData.image_url),
+      }
+
       const response = await fetch("/api/about", {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(aboutData),
+        body: JSON.stringify(payload),
       })
 
       if (response.ok) {

--- a/app/admin/board/[id]/edit/page.tsx
+++ b/app/admin/board/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/componen
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { BoardMember } from "@/lib/types"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 export default function EditBoardMemberPage({ params }: { params: { id: string } }) {
   const [boardMemberData, setBoardMemberData] = useState<Partial<BoardMember>>({
@@ -96,12 +97,17 @@ export default function EditBoardMemberPage({ params }: { params: { id: string }
     try {
       const memberId = boardMemberData.id || params.id
       console.log("[v0] Board Edit: Making PUT request to /api/board/" + memberId)
+      const payload = {
+        ...boardMemberData,
+        image_url: toGoogleDriveDirectUrl(boardMemberData.image_url),
+      }
+
       const response = await fetch(`/api/board/${memberId}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(boardMemberData),
+        body: JSON.stringify(payload),
       })
 
       console.log("[v0] Board Edit: Response status:", response.status)

--- a/app/admin/board/new/page.tsx
+++ b/app/admin/board/new/page.tsx
@@ -12,6 +12,7 @@ import { Save, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 export default function NewBoardMemberPage() {
   const { toast } = useToast()
@@ -32,12 +33,17 @@ export default function NewBoardMemberPage() {
     setLoading(true)
 
     try {
+      const payload = {
+        ...formData,
+        image_url: toGoogleDriveDirectUrl(formData.image_url),
+      }
+
       const response = await fetch("/api/board", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify(payload),
       })
 
       if (response.ok) {

--- a/app/admin/committees/[id]/edit/page.tsx
+++ b/app/admin/committees/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/componen
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { LocalCommittee } from "@/lib/types"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 export default function EditCommitteePage({ params }: { params: { id: string } }) {
   const [committeeData, setCommitteeData] = useState<Partial<LocalCommittee>>({
@@ -66,12 +67,17 @@ export default function EditCommitteePage({ params }: { params: { id: string } }
 
     setSaving(true)
     try {
+      const payload = {
+        ...committeeData,
+        logo_url: toGoogleDriveDirectUrl(committeeData.logo_url),
+      }
+
       const response = await fetch(`/api/committees/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(committeeData),
+        body: JSON.stringify(payload),
       })
 
       if (response.ok) {

--- a/app/admin/committees/new/page.tsx
+++ b/app/admin/committees/new/page.tsx
@@ -5,6 +5,7 @@ import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/componen
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { LocalCommittee } from "@/lib/types"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 export default function NewCommitteePage() {
   const [committeeData, setCommitteeData] = useState<Partial<LocalCommittee>>({
@@ -32,12 +33,17 @@ export default function NewCommitteePage() {
 
     setSaving(true)
     try {
+      const payload = {
+        ...committeeData,
+        logo_url: toGoogleDriveDirectUrl(committeeData.logo_url),
+      }
+
       const response = await fetch("/api/committees", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(committeeData),
+        body: JSON.stringify(payload),
       })
 
       if (response.ok) {

--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -15,6 +15,7 @@ import { ArrowLeft, Save } from "lucide-react"
 
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 interface EventFormData {
   title: string
@@ -123,12 +124,17 @@ export default function EditEventPage() {
     setLoading(true)
 
     try {
+      const payload = {
+        ...formData,
+        image_url: toGoogleDriveDirectUrl(formData.image_url),
+      }
+
       const response = await fetch(`/api/events/${eventId}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify(payload),
       })
 
       if (!response.ok) {

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -15,6 +15,7 @@ import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 export default function NewEventPage() {
   const { toast } = useToast()
@@ -45,12 +46,17 @@ export default function NewEventPage() {
     setLoading(true)
 
     try {
+      const payload = {
+        ...formData,
+        image_url: toGoogleDriveDirectUrl(formData.image_url),
+      }
+
       const response = await fetch("/api/events", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify(payload),
       })
 
       if (response.ok) {

--- a/app/admin/hero/page.tsx
+++ b/app/admin/hero/page.tsx
@@ -6,6 +6,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import type { HeroContent } from "@/lib/types"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 function toNullableString(value: string | null | undefined) {
   if (typeof value !== "string") {
@@ -87,7 +88,7 @@ export default function HeroAdminPage() {
         description: toNullableString(heroData.description),
         cta_text: toNullableString(heroData.cta_text),
         cta_link: toNullableString(heroData.cta_link),
-        background_image_url: toNullableString(heroData.background_image_url),
+        background_image_url: toGoogleDriveDirectUrl(heroData.background_image_url),
         is_active: heroData.is_active ?? true,
       }
 

--- a/app/admin/magazine/[id]/edit/page.tsx
+++ b/app/admin/magazine/[id]/edit/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/select"
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 interface MagazineIssueForm {
   title: string
@@ -130,7 +131,7 @@ export default function EditMagazineIssuePage() {
       const payload = {
         title: formData.title.trim(),
         description: formData.description.trim() || null,
-        cover_image_url: formData.cover_image_url.trim() || null,
+        cover_image_url: toGoogleDriveDirectUrl(formData.cover_image_url),
         pdf_url: formData.pdf_url.trim() || null,
         issue_number: formData.issue_number.trim(),
         publication_date: formData.publication_date,

--- a/app/admin/magazine/new/page.tsx
+++ b/app/admin/magazine/new/page.tsx
@@ -22,6 +22,7 @@ import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 export default function NewMagazineIssuePage() {
   const { toast } = useToast()
@@ -57,7 +58,7 @@ export default function NewMagazineIssuePage() {
       const payload = {
         title: formData.title.trim(),
         description: formData.description.trim() || null,
-        cover_image_url: formData.cover_image_url.trim() || null,
+        cover_image_url: toGoogleDriveDirectUrl(formData.cover_image_url),
         pdf_url: formData.pdf_url.trim() || null,
         issue_number: formData.issue_number.trim(),
         publication_date: formData.publication_date,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,62 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+const GOOGLE_DRIVE_HOSTNAMES = new Set([
+  "drive.google.com",
+  "docs.google.com",
+])
+
+function extractGoogleDriveFileId(url: URL): string | null {
+  const host = url.hostname.toLowerCase()
+  if (!GOOGLE_DRIVE_HOSTNAMES.has(host)) {
+    return null
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean)
+
+  if (segments.length >= 3 && segments[0] === "file" && segments[1] === "d") {
+    return segments[2]
+  }
+
+  if (segments[0] === "open" || segments[0] === "uc" || segments[0] === "thumbnail") {
+    const idParam = url.searchParams.get("id") || url.searchParams.get("ids")
+    if (idParam) {
+      return idParam
+    }
+  }
+
+  return null
+}
+
+export function toGoogleDriveDirectUrl(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const parsedUrl = new URL(trimmed)
+    const fileId = extractGoogleDriveFileId(parsedUrl)
+
+    if (fileId) {
+      return `https://drive.google.com/uc?export=view&id=${fileId}`
+    }
+  } catch (error) {
+    console.warn("Failed to parse URL while normalizing Google Drive link", error)
+  }
+
+  const fileIdMatch = trimmed.match(/https?:\/\/drive\.google\.com\/file\/d\/([\w-]+)/)
+  if (fileIdMatch?.[1]) {
+    return `https://drive.google.com/uc?export=view&id=${fileIdMatch[1]}`
+  }
+
+  return trimmed
 }


### PR DESCRIPTION
## Summary
- add a shared utility to convert Google Drive sharing links into direct image URLs
- apply the conversion across hero, about, board, committee, event, and magazine admin forms before persisting data

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7bb5ac574832fb4700849cf8c133e