### PR TITLE
Normalize Google Drive links in content records

### DIFF
--- a/app/api/events/utils.ts
+++ b/app/api/events/utils.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js"
 
 import { createClient, createServiceRoleClient } from "@/lib/supabase/server"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 const REGISTRATION_MAILTO_PREFIX = "mailto:"
 
@@ -121,6 +122,7 @@ export function normalizeEventRecord(event: Record<string, any>) {
     event_date: eventDate,
     registration_url: registrationUrl,
     is_active: typeof event.is_active === "boolean" ? event.is_active : true,
+    image_url: toGoogleDriveDirectUrl(event.image_url),
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared normalization utilities in the content service so hero, about, board, committee, contact, and magazine assets convert Google Drive share links before returning
- update the events API normalization to convert stored Google Drive image URLs into direct links

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7c24cb104832f9987d8fb9665bc4a