### PR TITLE
Handle non-http URLs when normalizing Google Drive links

### DIFF
--- a/app/api/events/utils.ts
+++ b/app/api/events/utils.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js"
 
 import { createClient, createServiceRoleClient } from "@/lib/supabase/server"
+import { toGoogleDriveDirectUrl } from "@/lib/utils"
 
 const REGISTRATION_MAILTO_PREFIX = "mailto:"
 
@@ -121,6 +122,7 @@ export function normalizeEventRecord(event: Record<string, any>) {
     event_date: eventDate,
     registration_url: registrationUrl,
     is_active: typeof event.is_active === "boolean" ? event.is_active : true,
+    image_url: toGoogleDriveDirectUrl(event.image_url),
   }
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -42,6 +42,10 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
     return null
   }
 
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return trimmed
+  }
+
   try {
     const parsedUrl = new URL(trimmed)
     const fileId = extractGoogleDriveFileId(parsedUrl)
@@ -51,6 +55,7 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
     }
   } catch (error) {
     console.warn("Failed to parse URL while normalizing Google Drive link", error)
+    return trimmed
   }
 
   const fileIdMatch = trimmed.match(/https?:\/\/drive\.google\.com\/file\/d\/([\w-]+)/)


### PR DESCRIPTION
## Summary
- avoid parsing non-http(s) strings when converting Google Drive sharing links to direct URLs
- ensure invalid/relative paths skip conversion after logging to keep existing assets visible

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7c24cb104832f9987d8fb9665bc4a