### PR TITLE
Render magazine covers from Google Drive

### DIFF
--- a/app/admin/about/page.tsx
+++ b/app/admin/about/page.tsx
@@ -5,6 +5,7 @@ import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/componen
 import { useToast } from "@/hooks/use-toast"
 import type { AboutContent } from "@/lib/types"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function AboutAdminPage() {
   const [aboutData, setAboutData] = useState<Partial<AboutContent>>({
@@ -132,7 +133,7 @@ export default function AboutAdminPage() {
           value={aboutData.image_url || ""}
           onChange={(value) => setAboutData((prev) => ({ ...prev, image_url: value }))}
           placeholder="https://example.com/about-image.jpg"
-          description="Optional image for the about section"
+          description={`Optional image for the about section. ${GOOGLE_DRIVE_IMAGE_HINT}`}
         />
 
         <TextAreaField

--- a/app/admin/board/[id]/edit/page.tsx
+++ b/app/admin/board/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { BoardMember } from "@/lib/types"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function EditBoardMemberPage({ params }: { params: { id: string } }) {
   const [boardMemberData, setBoardMemberData] = useState<Partial<BoardMember>>({
@@ -200,7 +201,7 @@ export default function EditBoardMemberPage({ params }: { params: { id: string }
               value={boardMemberData.image_url || ""}
               onChange={(value) => setBoardMemberData((prev) => ({ ...prev, image_url: value }))}
               placeholder="https://example.com/image.jpg"
-              description="URL to the board member's profile photo"
+              description={`URL to the board member's profile photo. ${GOOGLE_DRIVE_IMAGE_HINT}`}
             />
 
             <TextField

--- a/app/admin/board/new/page.tsx
+++ b/app/admin/board/new/page.tsx
@@ -13,6 +13,7 @@ import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewBoardMemberPage() {
   const { toast } = useToast()
@@ -135,6 +136,7 @@ export default function NewBoardMemberPage() {
                   onChange={(e) => handleChange("image_url", e.target.value)}
                   placeholder="https://example.com/image.jpg"
                 />
+                <p className="text-xs text-muted-foreground">{GOOGLE_DRIVE_IMAGE_HINT}</p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="display_order">Display Order</Label>

--- a/app/admin/committees/[id]/edit/page.tsx
+++ b/app/admin/committees/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { LocalCommittee } from "@/lib/types"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function EditCommitteePage({ params }: { params: { id: string } }) {
   const [committeeData, setCommitteeData] = useState<Partial<LocalCommittee>>({
@@ -161,7 +162,7 @@ export default function EditCommitteePage({ params }: { params: { id: string } }
           value={committeeData.logo_url || ""}
           onChange={(value) => setCommitteeData((prev) => ({ ...prev, logo_url: value }))}
           placeholder="https://example.com/logo.png"
-          description="URL to the committee's logo image"
+          description={`URL to the committee's logo image. ${GOOGLE_DRIVE_IMAGE_HINT}`}
         />
 
         <TextAreaField

--- a/app/admin/committees/new/page.tsx
+++ b/app/admin/committees/new/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { LocalCommittee } from "@/lib/types"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewCommitteePage() {
   const [committeeData, setCommitteeData] = useState<Partial<LocalCommittee>>({
@@ -110,7 +111,7 @@ export default function NewCommitteePage() {
           value={committeeData.logo_url || ""}
           onChange={(value) => setCommitteeData((prev) => ({ ...prev, logo_url: value }))}
           placeholder="https://example.com/logo.png"
-          description="URL to the committee's logo image"
+          description={`URL to the committee's logo image. ${GOOGLE_DRIVE_IMAGE_HINT}`}
         />
 
         <TextAreaField

--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -16,6 +16,7 @@ import { ArrowLeft, Save } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 interface EventFormData {
   title: string
@@ -254,6 +255,7 @@ export default function EditEventPage() {
                     onChange={(e) => handleChange("image_url", e.target.value)}
                     placeholder="https://example.com/event-image.jpg"
                   />
+                  <p className="text-xs text-muted-foreground">{GOOGLE_DRIVE_IMAGE_HINT}</p>
                 </div>
               </div>
 

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -16,6 +16,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewEventPage() {
   const { toast } = useToast()
@@ -176,6 +177,7 @@ export default function NewEventPage() {
                   onChange={(e) => handleChange("image_url", e.target.value)}
                   placeholder="https://example.com/event-image.jpg"
                 />
+                <p className="text-xs text-muted-foreground">{GOOGLE_DRIVE_IMAGE_HINT}</p>
               </div>
             </div>
 

--- a/app/admin/hero/page.tsx
+++ b/app/admin/hero/page.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import type { HeroContent } from "@/lib/types"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 function toNullableString(value: string | null | undefined) {
   if (typeof value !== "string") {
@@ -229,7 +230,7 @@ export default function HeroAdminPage() {
           value={heroData.background_image_url || ""}
           onChange={(value) => setHeroData((prev) => ({ ...prev, background_image_url: value }))}
           placeholder="https://example.com/image.jpg"
-          description="Optional background image for the hero section"
+          description={`Optional background image for the hero section. ${GOOGLE_DRIVE_IMAGE_HINT}`}
         />
 
         <SwitchField

--- a/app/admin/magazine/[id]/edit/page.tsx
+++ b/app/admin/magazine/[id]/edit/page.tsx
@@ -23,6 +23,7 @@ import {
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 interface MagazineIssueForm {
   title: string
@@ -296,6 +297,7 @@ export default function EditMagazineIssuePage() {
                   onChange={(event) => handleChange("cover_image_url", event.target.value)}
                   placeholder="https://example.com/cover.jpg"
                 />
+                <p className="text-xs text-muted-foreground">{GOOGLE_DRIVE_IMAGE_HINT}</p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="pdf_url">PDF URL</Label>

--- a/app/admin/magazine/new/page.tsx
+++ b/app/admin/magazine/new/page.tsx
@@ -23,6 +23,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewMagazineIssuePage() {
   const { toast } = useToast()
@@ -209,6 +210,7 @@ export default function NewMagazineIssuePage() {
                   onChange={(e) => handleChange("cover_image_url", e.target.value)}
                   placeholder="https://example.com/cover.jpg"
                 />
+                <p className="text-xs text-muted-foreground">{GOOGLE_DRIVE_IMAGE_HINT}</p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="pdf_url">PDF URL</Label>

--- a/app/magazines/page.tsx
+++ b/app/magazines/page.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image"
+
 import { Navigation } from "@/components/navigation"
 import { Footer } from "@/components/footer"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -98,13 +100,30 @@ export default async function MagazinesPage() {
                       <Badge className="absolute top-4 right-4 bg-accent text-accent-foreground z-10">Featured</Badge>
                     )}
                     <CardHeader>
-                      <div className="aspect-[3/4] bg-gradient-to-br from-primary/20 to-accent/20 rounded-lg mb-4 flex items-center justify-center group-hover:from-primary/30 group-hover:to-accent/30 transition-colors">
-                        <div className="text-center p-4">
-                          <div className="text-2xl font-bold text-foreground mb-2">
-                            {issue.issue_number ?? "Issue pending"}
+                      <div className="relative aspect-[3/4] overflow-hidden rounded-lg mb-4">
+                        {issue.cover_image_url ? (
+                          <>
+                            <Image
+                              src={issue.cover_image_url}
+                              alt={`${issue.title} cover art`}
+                              fill
+                              className="object-cover"
+                              sizes="(min-width: 1024px) 320px, (min-width: 768px) 45vw, 90vw"
+                            />
+                            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-80 group-hover:opacity-90 transition-opacity" />
+                            <div className="absolute inset-x-0 bottom-0 p-4 text-white">
+                              <div className="text-xs uppercase tracking-wide text-white/80">IACES Magazine</div>
+                              <div className="text-xl font-semibold">{issue.issue_number ?? "Issue pending"}</div>
+                            </div>
+                          </>
+                        ) : (
+                          <div className="flex h-full w-full flex-col items-center justify-center bg-gradient-to-br from-primary/20 to-accent/20 p-6 text-center transition-colors group-hover:from-primary/30 group-hover:to-accent/30">
+                            <div className="text-2xl font-bold text-foreground mb-2">
+                              {issue.issue_number ?? "Issue pending"}
+                            </div>
+                            <div className="text-sm text-muted-foreground">IACES Magazine</div>
                           </div>
-                          <div className="text-sm text-muted-foreground">IACES Magazine</div>
-                        </div>
+                        )}
                       </div>
                       <CardTitle className="text-lg">{issue.title}</CardTitle>
                     </CardHeader>
@@ -147,13 +166,30 @@ export default async function MagazinesPage() {
                 {newsletters.map((newsletter) => (
                   <Card key={newsletter.id} className="group hover:shadow-lg transition-shadow">
                     <CardHeader>
-                      <div className="aspect-[4/3] bg-gradient-to-br from-secondary/20 to-muted/20 rounded-lg mb-4 flex items-center justify-center group-hover:from-secondary/30 group-hover:to-muted/30 transition-colors">
-                        <div className="text-center p-4">
-                          <div className="text-xl font-bold text-foreground mb-2">
-                            {newsletter.issue_number ?? "Newsletter"}
+                      <div className="relative aspect-[4/3] overflow-hidden rounded-lg mb-4">
+                        {newsletter.cover_image_url ? (
+                          <>
+                            <Image
+                              src={newsletter.cover_image_url}
+                              alt={`${newsletter.title} cover art`}
+                              fill
+                              className="object-cover"
+                              sizes="(min-width: 1024px) 320px, (min-width: 768px) 45vw, 90vw"
+                            />
+                            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-80 group-hover:opacity-90 transition-opacity" />
+                            <div className="absolute inset-x-0 bottom-0 p-4 text-white">
+                              <div className="text-xs uppercase tracking-wide text-white/80">IACES Newsletter</div>
+                              <div className="text-lg font-semibold">{newsletter.issue_number ?? "Newsletter"}</div>
+                            </div>
+                          </>
+                        ) : (
+                          <div className="flex h-full w-full flex-col items-center justify-center bg-gradient-to-br from-secondary/20 to-muted/20 p-6 text-center transition-colors group-hover:from-secondary/30 group-hover:to-muted/30">
+                            <div className="text-xl font-bold text-foreground mb-2">
+                              {newsletter.issue_number ?? "Newsletter"}
+                            </div>
+                            <div className="text-sm text-muted-foreground">IACES Newsletter</div>
                           </div>
-                          <div className="text-sm text-muted-foreground">IACES Newsletter</div>
-                        </div>
+                        )}
                       </div>
                       <CardTitle className="text-lg">{newsletter.title}</CardTitle>
                     </CardHeader>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,4 @@
+export const GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE =
+  "https://drive.google.com/uc?export=view&id=1JydVFz0V6GXpmD94GfHdRz0_XQFzOwOT"
+
+export const GOOGLE_DRIVE_IMAGE_HINT = `Supports Google Drive links (e.g. ${GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE}).`

--- a/lib/fallback-data.ts
+++ b/lib/fallback-data.ts
@@ -1,3 +1,4 @@
+import { GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE } from "@/lib/constants"
 import type {
   AboutContent,
   BoardMember,
@@ -281,7 +282,7 @@ export const fallbackMagazineIssuesForAdmin: MagazineArticle[] = [
     title: "The Future of Civil Engineering",
     description:
       "Exploring emerging technologies, sustainable practices, and the global impact of student-led research.",
-    cover_image_url: null,
+    cover_image_url: GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE,
     pdf_url: null,
     issue_number: "Vol. 15, Issue 3",
     publication_date: "2024-09-01T00:00:00.000Z",
@@ -297,7 +298,7 @@ export const fallbackMagazineIssuesForAdmin: MagazineArticle[] = [
     title: "Infrastructure Innovation Digest",
     description:
       "Highlighting cross-border collaboration projects and new materials shaping resilient infrastructure.",
-    cover_image_url: null,
+    cover_image_url: GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE,
     pdf_url: null,
     issue_number: "Vol. 15, Issue 2",
     publication_date: "2024-06-01T00:00:00.000Z",
@@ -312,7 +313,7 @@ export const fallbackMagazineIssuesForAdmin: MagazineArticle[] = [
     id: "fallback-newsletter-1",
     title: "Monthly Newsletter - September 2024",
     description: "Conference highlights, new partnerships, and student achievement recognitions.",
-    cover_image_url: null,
+    cover_image_url: GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE,
     pdf_url: null,
     issue_number: "Newsletter #9",
     publication_date: "2024-09-01T00:00:00.000Z",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,23 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "drive.google.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "docs.google.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**",
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Summary
- render magazine and newsletter cards with cover art when Google Drive URLs are available
- add Google Drive example cover images to fallback magazine data so the gallery has meaningful placeholders

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7c938826c832f89a83742672b0850