### PR TITLE
Use Google Drive download endpoint for direct images

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,4 @@
 export const GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE =
-  "https://drive.google.com/uc?export=view&id=1JydVFz0V6GXpmD94GfHdRz0_XQFzOwOT"
+  "https://drive.google.com/uc?export=download&id=1JydVFz0V6GXpmD94GfHdRz0_XQFzOwOT"
 
 export const GOOGLE_DRIVE_IMAGE_HINT = `Supports Google Drive links (e.g. ${GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE}).`

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -51,7 +51,7 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
     const fileId = extractGoogleDriveFileId(parsedUrl)
 
     if (fileId) {
-      return `https://drive.google.com/uc?export=view&id=${fileId}`
+      return `https://drive.google.com/uc?export=download&id=${fileId}`
     }
   } catch (error) {
     console.warn("Failed to parse URL while normalizing Google Drive link", error)
@@ -60,7 +60,7 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
 
   const fileIdMatch = trimmed.match(/https?:\/\/drive\.google\.com\/file\/d\/([\w-]+)/)
   if (fileIdMatch?.[1]) {
-    return `https://drive.google.com/uc?export=view&id=${fileIdMatch[1]}`
+    return `https://drive.google.com/uc?export=download&id=${fileIdMatch[1]}`
   }
 
   return trimmed


### PR DESCRIPTION
## Summary
- update the Google Drive normalization helper to return direct download URLs for assets
- refresh the shared Google Drive hint text to document the new URL format

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d35ae1fc832f8b66c611a24eb73d