### PR TITLE
Normalize Google Drive magazine cover links

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,5 @@
 export const GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE =
   "https://drive.google.com/uc?export=download&id=1JydVFz0V6GXpmD94GfHdRz0_XQFzOwOT"
 
-export const GOOGLE_DRIVE_IMAGE_HINT = `Supports Google Drive links (e.g. ${GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE}).`
+export const GOOGLE_DRIVE_IMAGE_HINT =
+  `Supports Google Drive share links and converts them to direct image URLs (e.g. ${GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE}).`

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,12 @@ const GOOGLE_DRIVE_HOSTNAMES = new Set([
   "docs.google.com",
 ])
 
+const createGoogleDriveDownloadUrl = (fileId: string) =>
+  `https://drive.google.com/uc?export=download&id=${fileId}`
+
+const createGoogleDriveThumbnailUrl = (fileId: string) =>
+  `https://drive.google.com/thumbnail?id=${fileId}&sz=w2048`
+
 function extractGoogleDriveFileId(url: URL): string | null {
   const host = url.hostname.toLowerCase()
   if (!GOOGLE_DRIVE_HOSTNAMES.has(host)) {
@@ -51,7 +57,11 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
     const fileId = extractGoogleDriveFileId(parsedUrl)
 
     if (fileId) {
-      return `https://drive.google.com/uc?export=download&id=${fileId}`
+      if (parsedUrl.pathname.startsWith("/thumbnail")) {
+        return createGoogleDriveThumbnailUrl(fileId)
+      }
+
+      return createGoogleDriveDownloadUrl(fileId)
     }
   } catch (error) {
     console.warn("Failed to parse URL while normalizing Google Drive link", error)
@@ -60,7 +70,7 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
 
   const fileIdMatch = trimmed.match(/https?:\/\/drive\.google\.com\/file\/d\/([\w-]+)/)
   if (fileIdMatch?.[1]) {
-    return `https://drive.google.com/uc?export=download&id=${fileIdMatch[1]}`
+    return createGoogleDriveDownloadUrl(fileIdMatch[1])
   }
 
   return trimmed


### PR DESCRIPTION
## Summary
- normalize Google Drive links to return direct download or thumbnail URLs so magazine covers stream the raw image
- refresh the admin hint to clarify that share links are converted to direct image URLs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d899a93c832fa61fa103afecb655