### PR TITLE
Ensure Google Drive covers use thumbnail endpoints

### DIFF
--- a/app/admin/about/page.tsx
+++ b/app/admin/about/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/components/admin/content-editor"
 import { useToast } from "@/hooks/use-toast"
 import type { AboutContent } from "@/lib/types"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function AboutAdminPage() {
@@ -51,7 +51,7 @@ export default function AboutAdminPage() {
     try {
       const payload = {
         ...aboutData,
-        image_url: toGoogleDriveDirectUrl(aboutData.image_url),
+        image_url: toGoogleDriveImageUrl(aboutData.image_url),
       }
 
       const response = await fetch("/api/about", {

--- a/app/admin/board/[id]/edit/page.tsx
+++ b/app/admin/board/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/componen
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { BoardMember } from "@/lib/types"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function EditBoardMemberPage({ params }: { params: { id: string } }) {
@@ -100,7 +100,7 @@ export default function EditBoardMemberPage({ params }: { params: { id: string }
       console.log("[v0] Board Edit: Making PUT request to /api/board/" + memberId)
       const payload = {
         ...boardMemberData,
-        image_url: toGoogleDriveDirectUrl(boardMemberData.image_url),
+        image_url: toGoogleDriveImageUrl(boardMemberData.image_url),
       }
 
       const response = await fetch(`/api/board/${memberId}`, {

--- a/app/admin/board/new/page.tsx
+++ b/app/admin/board/new/page.tsx
@@ -12,7 +12,7 @@ import { Save, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewBoardMemberPage() {
@@ -36,7 +36,7 @@ export default function NewBoardMemberPage() {
     try {
       const payload = {
         ...formData,
-        image_url: toGoogleDriveDirectUrl(formData.image_url),
+        image_url: toGoogleDriveImageUrl(formData.image_url),
       }
 
       const response = await fetch("/api/board", {

--- a/app/admin/committees/[id]/edit/page.tsx
+++ b/app/admin/committees/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/componen
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { LocalCommittee } from "@/lib/types"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function EditCommitteePage({ params }: { params: { id: string } }) {
@@ -70,7 +70,7 @@ export default function EditCommitteePage({ params }: { params: { id: string } }
     try {
       const payload = {
         ...committeeData,
-        logo_url: toGoogleDriveDirectUrl(committeeData.logo_url),
+        logo_url: toGoogleDriveImageUrl(committeeData.logo_url),
       }
 
       const response = await fetch(`/api/committees/${params.id}`, {

--- a/app/admin/committees/new/page.tsx
+++ b/app/admin/committees/new/page.tsx
@@ -5,7 +5,7 @@ import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/componen
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { LocalCommittee } from "@/lib/types"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewCommitteePage() {
@@ -36,7 +36,7 @@ export default function NewCommitteePage() {
     try {
       const payload = {
         ...committeeData,
-        logo_url: toGoogleDriveDirectUrl(committeeData.logo_url),
+        logo_url: toGoogleDriveImageUrl(committeeData.logo_url),
       }
 
       const response = await fetch("/api/committees", {

--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -15,7 +15,7 @@ import { ArrowLeft, Save } from "lucide-react"
 
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 interface EventFormData {
@@ -127,7 +127,7 @@ export default function EditEventPage() {
     try {
       const payload = {
         ...formData,
-        image_url: toGoogleDriveDirectUrl(formData.image_url),
+        image_url: toGoogleDriveImageUrl(formData.image_url),
       }
 
       const response = await fetch(`/api/events/${eventId}`, {

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -15,7 +15,7 @@ import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewEventPage() {
@@ -49,7 +49,7 @@ export default function NewEventPage() {
     try {
       const payload = {
         ...formData,
-        image_url: toGoogleDriveDirectUrl(formData.image_url),
+        image_url: toGoogleDriveImageUrl(formData.image_url),
       }
 
       const response = await fetch("/api/events", {

--- a/app/admin/hero/page.tsx
+++ b/app/admin/hero/page.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
 import type { HeroContent } from "@/lib/types"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 function toNullableString(value: string | null | undefined) {
@@ -89,7 +89,7 @@ export default function HeroAdminPage() {
         description: toNullableString(heroData.description),
         cta_text: toNullableString(heroData.cta_text),
         cta_link: toNullableString(heroData.cta_link),
-        background_image_url: toGoogleDriveDirectUrl(heroData.background_image_url),
+        background_image_url: toGoogleDriveImageUrl(heroData.background_image_url),
         is_active: heroData.is_active ?? true,
       }
 

--- a/app/admin/magazine/[id]/edit/page.tsx
+++ b/app/admin/magazine/[id]/edit/page.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/select"
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 interface MagazineIssueForm {
@@ -73,7 +73,7 @@ export default function EditMagazineIssuePage() {
           title: data.title ?? "",
           issue_number: data.issue_number ?? "",
           description: data.description ?? "",
-          cover_image_url: toGoogleDriveDirectUrl(data.cover_image_url) ?? "",
+          cover_image_url: toGoogleDriveImageUrl(data.cover_image_url) ?? "",
           pdf_url: data.pdf_url ?? "",
           publication_date: data.publication_date
             ? new Date(data.publication_date).toISOString().split("T")[0]
@@ -132,7 +132,7 @@ export default function EditMagazineIssuePage() {
       const payload = {
         title: formData.title.trim(),
         description: formData.description.trim() || null,
-        cover_image_url: toGoogleDriveDirectUrl(formData.cover_image_url),
+        cover_image_url: toGoogleDriveImageUrl(formData.cover_image_url),
         pdf_url: formData.pdf_url.trim() || null,
         issue_number: formData.issue_number.trim(),
         publication_date: formData.publication_date,

--- a/app/admin/magazine/new/page.tsx
+++ b/app/admin/magazine/new/page.tsx
@@ -22,7 +22,7 @@ import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 import { GOOGLE_DRIVE_IMAGE_HINT } from "@/lib/constants"
 
 export default function NewMagazineIssuePage() {
@@ -59,7 +59,7 @@ export default function NewMagazineIssuePage() {
       const payload = {
         title: formData.title.trim(),
         description: formData.description.trim() || null,
-        cover_image_url: toGoogleDriveDirectUrl(formData.cover_image_url),
+        cover_image_url: toGoogleDriveImageUrl(formData.cover_image_url),
         pdf_url: formData.pdf_url.trim() || null,
         issue_number: formData.issue_number.trim(),
         publication_date: formData.publication_date,

--- a/app/admin/magazine/page.tsx
+++ b/app/admin/magazine/page.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { useToast } from "@/hooks/use-toast"
 import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 
 interface MagazineIssue {
   id: string
@@ -54,7 +54,7 @@ export default function AdminMagazinePage() {
         const normalized: MagazineIssue[] = Array.isArray(data)
           ? data.map((issue) => ({
               ...issue,
-              cover_image_url: toGoogleDriveDirectUrl(issue.cover_image_url),
+              cover_image_url: toGoogleDriveImageUrl(issue.cover_image_url),
             }))
           : []
 

--- a/app/api/events/utils.ts
+++ b/app/api/events/utils.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js"
 
 import { createClient, createServiceRoleClient } from "@/lib/supabase/server"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 
 const REGISTRATION_MAILTO_PREFIX = "mailto:"
 
@@ -122,7 +122,7 @@ export function normalizeEventRecord(event: Record<string, any>) {
     event_date: eventDate,
     registration_url: registrationUrl,
     is_active: typeof event.is_active === "boolean" ? event.is_active : true,
-    image_url: toGoogleDriveDirectUrl(event.image_url),
+    image_url: toGoogleDriveImageUrl(event.image_url),
   }
 }
 

--- a/app/api/magazines/[id]/route.ts
+++ b/app/api/magazines/[id]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 
 export const dynamic = "force-dynamic"
 
@@ -28,7 +28,7 @@ export async function GET(_request: NextRequest, { params }: { params: { id: str
 
     return NextResponse.json({
       ...data,
-      cover_image_url: toGoogleDriveDirectUrl(data.cover_image_url),
+      cover_image_url: toGoogleDriveImageUrl(data.cover_image_url),
       publication_type: data.publication_type === "newsletter" ? "newsletter" : "magazine",
     })
   } catch (error) {
@@ -65,7 +65,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 
     const sanitizeOptionalUrl = (value: unknown) => {
       const sanitized = sanitizeOptionalString(value)
-      return sanitized ? toGoogleDriveDirectUrl(sanitized) : null
+      return sanitized ? toGoogleDriveImageUrl(sanitized) : null
     }
 
     const updates: Record<string, unknown> = {}
@@ -148,7 +148,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 
     return NextResponse.json({
       ...data,
-      cover_image_url: toGoogleDriveDirectUrl(data.cover_image_url),
+      cover_image_url: toGoogleDriveImageUrl(data.cover_image_url),
       publication_type: data.publication_type === "newsletter" ? "newsletter" : "magazine",
     })
   } catch (error) {

--- a/app/api/magazines/route.ts
+++ b/app/api/magazines/route.ts
@@ -1,14 +1,14 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { fallbackMagazineIssuesForAdmin } from "@/lib/fallback-data"
-import { toGoogleDriveDirectUrl } from "@/lib/utils"
+import { toGoogleDriveImageUrl } from "@/lib/utils"
 
 export const dynamic = "force-dynamic"
 
 const mapFallbackIssues = () =>
   fallbackMagazineIssuesForAdmin.map((article) => ({
     ...article,
-    cover_image_url: toGoogleDriveDirectUrl(article.cover_image_url),
+    cover_image_url: toGoogleDriveImageUrl(article.cover_image_url),
   }))
 
 export async function GET() {
@@ -36,7 +36,7 @@ export async function GET() {
 
     const normalized = (data ?? []).map((article) => ({
       ...article,
-      cover_image_url: toGoogleDriveDirectUrl(article.cover_image_url),
+      cover_image_url: toGoogleDriveImageUrl(article.cover_image_url),
       publication_type: article.publication_type === "newsletter" ? "newsletter" : "magazine",
     }))
 
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
 
     const sanitizeOptionalUrl = (value: unknown) => {
       const sanitized = sanitizeOptionalString(value)
-      return sanitized ? toGoogleDriveDirectUrl(sanitized) : null
+      return sanitized ? toGoogleDriveImageUrl(sanitized) : null
     }
 
     if (

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,5 @@
 export const GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE =
-  "https://drive.google.com/uc?export=download&id=1JydVFz0V6GXpmD94GfHdRz0_XQFzOwOT"
+  "https://drive.google.com/thumbnail?id=1JydVFz0V6GXpmD94GfHdRz0_XQFzOwOT&sz=w2048"
 
-export const GOOGLE_DRIVE_IMAGE_HINT = `Supports Google Drive links (e.g. ${GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE}).`
+export const GOOGLE_DRIVE_IMAGE_HINT =
+  `Supports Google Drive share links and converts them to direct image URLs (e.g. ${GOOGLE_DRIVE_DIRECT_LINK_EXAMPLE}).`

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,12 @@ const GOOGLE_DRIVE_HOSTNAMES = new Set([
   "docs.google.com",
 ])
 
+const createGoogleDriveDownloadUrl = (fileId: string) =>
+  `https://drive.google.com/uc?export=download&id=${fileId}`
+
+const createGoogleDriveThumbnailUrl = (fileId: string, size: number = 2048) =>
+  `https://drive.google.com/thumbnail?id=${fileId}&sz=w${Math.max(32, size)}`
+
 function extractGoogleDriveFileId(url: URL): string | null {
   const host = url.hostname.toLowerCase()
   if (!GOOGLE_DRIVE_HOSTNAMES.has(host)) {
@@ -32,7 +38,15 @@ function extractGoogleDriveFileId(url: URL): string | null {
   return null
 }
 
-export function toGoogleDriveDirectUrl(value: string | null | undefined): string | null {
+export type GoogleDriveDirectUrlOptions = {
+  preferThumbnail?: boolean
+  thumbnailSize?: number
+}
+
+export function toGoogleDriveDirectUrl(
+  value: string | null | undefined,
+  options?: GoogleDriveDirectUrlOptions,
+): string | null {
   if (typeof value !== "string") {
     return null
   }
@@ -51,7 +65,11 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
     const fileId = extractGoogleDriveFileId(parsedUrl)
 
     if (fileId) {
-      return `https://drive.google.com/uc?export=download&id=${fileId}`
+      if (options?.preferThumbnail || parsedUrl.pathname.startsWith("/thumbnail")) {
+        return createGoogleDriveThumbnailUrl(fileId, options?.thumbnailSize)
+      }
+
+      return createGoogleDriveDownloadUrl(fileId)
     }
   } catch (error) {
     console.warn("Failed to parse URL while normalizing Google Drive link", error)
@@ -60,8 +78,18 @@ export function toGoogleDriveDirectUrl(value: string | null | undefined): string
 
   const fileIdMatch = trimmed.match(/https?:\/\/drive\.google\.com\/file\/d\/([\w-]+)/)
   if (fileIdMatch?.[1]) {
-    return `https://drive.google.com/uc?export=download&id=${fileIdMatch[1]}`
+    if (options?.preferThumbnail) {
+      return createGoogleDriveThumbnailUrl(fileIdMatch[1], options?.thumbnailSize)
+    }
+    return createGoogleDriveDownloadUrl(fileIdMatch[1])
   }
 
   return trimmed
+}
+
+export function toGoogleDriveImageUrl(
+  value: string | null | undefined,
+  size?: number,
+): string | null {
+  return toGoogleDriveDirectUrl(value, { preferThumbnail: true, thumbnailSize: size })
 }


### PR DESCRIPTION
## Summary
- add configurable Google Drive URL normalization along with a dedicated image helper that returns thumbnail endpoints for share links
- update content service, APIs, and admin forms to normalize image fields with the thumbnail helper while keeping PDFs on direct download links
- refresh the admin hint example to demonstrate the new Google Drive thumbnail URL format

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d899a93c832fa61fa103afecb655