### PR TITLE
Update hero and about sections and remove magazine featured badge

### DIFF
--- a/components/about-section.tsx
+++ b/components/about-section.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import Image from "next/image"
 import { useEffect, useState } from "react"
+
 import { Card, CardContent } from "@/components/ui/card"
 import type { AboutContent } from "@/lib/types"
 import { fallbackAboutContent } from "@/lib/fallback-data"
@@ -74,48 +76,102 @@ export function AboutSection() {
   return (
     <section id="about" className="py-20 bg-secondary/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">{content.title}</h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">{content.content}</p>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-12 items-start mb-16">
-          {hasMissionOrVision && (
-            <div className="space-y-8">
-              {missionStatement && (
-                <div className="space-y-3">
-                  <h3 className="text-2xl font-semibold text-foreground">Our Mission</h3>
-                  <p className="text-muted-foreground leading-relaxed">{missionStatement}</p>
-                </div>
-              )}
-
-              {visionStatement && (
-                <div className="space-y-3">
-                  <h3 className="text-2xl font-semibold text-foreground">Our Vision</h3>
-                  <p className="text-muted-foreground leading-relaxed">{visionStatement}</p>
-                </div>
-              )}
+        <div className="grid items-start gap-12 lg:grid-cols-[1.1fr,0.9fr]">
+          <div className="space-y-10">
+            <div className="space-y-5">
+              <span className="inline-flex items-center gap-2 text-sm font-semibold text-accent">
+                <span className="h-px w-8 bg-accent" />
+                Who We Are
+              </span>
+              <h2 className="text-3xl md:text-4xl font-bold text-foreground leading-tight">{content.title}</h2>
+              <p className="text-lg text-muted-foreground leading-relaxed">{content.content}</p>
             </div>
-          )}
 
-          <div className="grid grid-cols-2 gap-4 md:ml-auto">
-            {highlights.map((highlight) => (
-              <Card key={highlight.label}>
-                <CardContent className="p-6 text-center">
-                  <div className="text-3xl font-bold text-accent mb-2">{highlight.value}</div>
-                  <div className="text-sm text-muted-foreground">{highlight.label}</div>
-                </CardContent>
-              </Card>
-            ))}
+            {hasMissionOrVision && (
+              <div className="grid gap-6 sm:grid-cols-2">
+                {missionStatement && (
+                  <Card className="h-full border-none bg-background/80 shadow-lg shadow-secondary/20 ring-1 ring-secondary/30">
+                    <CardContent className="flex h-full flex-col gap-3 p-6">
+                      <h3 className="text-xl font-semibold text-foreground">Our Mission</h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">{missionStatement}</p>
+                    </CardContent>
+                  </Card>
+                )}
+
+                {visionStatement && (
+                  <Card className="h-full border-none bg-background/80 shadow-lg shadow-secondary/20 ring-1 ring-secondary/30">
+                    <CardContent className="flex h-full flex-col gap-3 p-6">
+                      <h3 className="text-xl font-semibold text-foreground">Our Vision</h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">{visionStatement}</p>
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4 sm:max-w-xl">
+              {highlights.map((highlight) => (
+                <Card key={highlight.label} className="border-none bg-secondary/40 backdrop-blur">
+                  <CardContent className="p-6">
+                    <div className="text-3xl font-bold text-foreground">{highlight.value}</div>
+                    <div className="text-sm text-muted-foreground">{highlight.label}</div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-8">
+            <div className="relative aspect-[4/5] overflow-hidden rounded-3xl border border-secondary/40 bg-gradient-to-br from-secondary/20 via-primary/10 to-accent/20 shadow-xl">
+              {content.image_url ? (
+                <Image
+                  src={content.image_url}
+                  alt={content.title}
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 1024px) 28rem, 100vw"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-secondary/20 px-8 text-center">
+                  <div className="space-y-3">
+                    <h3 className="text-2xl font-semibold text-foreground">A Global Community</h3>
+                    <p className="text-muted-foreground text-sm">
+                      Students, educators, and professionals collaborating to shape the future of civil engineering.
+                    </p>
+                  </div>
+                </div>
+              )}
+              <div className="absolute inset-0 bg-gradient-to-t from-background/60 via-transparent to-transparent" />
+            </div>
+
+            <Card className="border-none bg-background/90 shadow-xl shadow-secondary/20 ring-1 ring-secondary/30">
+              <CardContent className="space-y-4 p-6">
+                <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">What we build together</p>
+                <ul className="space-y-2 text-sm text-muted-foreground">
+                  <li className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-accent" />
+                    Global exchange programs and study visits
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-accent" />
+                    Professional mentorship and lifelong networks
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-accent" />
+                    Hands-on projects advancing sustainable infrastructure
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
           </div>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-8">
+        <div className="mt-16 grid gap-8 md:grid-cols-3">
           {pillars.map((pillar) => (
-            <Card key={pillar.title}>
-              <CardContent className="p-6">
-                <h4 className="text-lg font-semibold text-foreground mb-3">{pillar.title}</h4>
-                <p className="text-muted-foreground text-sm">{pillar.description}</p>
+            <Card key={pillar.title} className="border-none bg-background/80 shadow-md shadow-secondary/20 ring-1 ring-secondary/30">
+              <CardContent className="p-6 space-y-3">
+                <h4 className="text-lg font-semibold text-foreground">{pillar.title}</h4>
+                <p className="text-sm text-muted-foreground leading-relaxed">{pillar.description}</p>
               </CardContent>
             </Card>
           ))}

--- a/components/dynamic-hero-section.tsx
+++ b/components/dynamic-hero-section.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
@@ -25,10 +26,23 @@ export async function DynamicHeroSection() {
   }
 
   return (
-    <section className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-secondary/20">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          <div className="space-y-8">
+    <section className="relative overflow-hidden bg-gradient-to-br from-background via-background to-secondary/20">
+      <div className="absolute inset-0 opacity-20">
+        {content.background_image_url && (
+          <Image
+            src={content.background_image_url}
+            alt={content.title}
+            fill
+            priority
+            className="object-cover"
+            sizes="100vw"
+          />
+        )}
+      </div>
+      <div className="absolute inset-0 bg-gradient-to-br from-background/80 via-background/60 to-secondary/30" />
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+        <div className="grid lg:grid-cols-[1fr,0.9fr] gap-12 items-center">
+          <div className="space-y-10">
             <div className="space-y-4">
               <h1 className="text-4xl md:text-6xl font-bold text-foreground leading-tight">{content.title}</h1>
               {content.subtitle && <p className="text-2xl text-accent font-medium">{content.subtitle}</p>}
@@ -46,7 +60,7 @@ export async function DynamicHeroSection() {
               </Button>
             </div>
 
-            <div className="flex items-center space-x-8 text-sm text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-6 text-sm text-muted-foreground">
               <div className="flex items-center space-x-2">
                 <div className="w-2 h-2 bg-accent rounded-full"></div>
                 <span>Global Network</span>
@@ -63,14 +77,34 @@ export async function DynamicHeroSection() {
           </div>
 
           <div className="relative">
-            <div className="aspect-square bg-gradient-to-br from-accent/20 to-primary/20 rounded-2xl flex items-center justify-center">
-              <div className="text-center space-y-4 p-8">
-                <div className="w-24 h-24 bg-accent/20 rounded-full flex items-center justify-center mx-auto">
-                  <div className="w-12 h-12 bg-accent rounded-full"></div>
+            <div className="relative aspect-[4/5] overflow-hidden rounded-3xl border border-secondary/40 shadow-xl">
+              {content.background_image_url ? (
+                <Image
+                  src={content.background_image_url}
+                  alt={content.title}
+                  fill
+                  priority
+                  className="object-cover"
+                  sizes="(min-width: 1024px) 32rem, 100vw"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-accent/10 via-primary/10 to-secondary/20">
+                  <div className="text-center space-y-3 px-8">
+                    <h3 className="text-2xl font-semibold text-foreground">Building Tomorrow's Infrastructure</h3>
+                    <p className="text-muted-foreground">Empowering the next generation of civil engineers</p>
+                  </div>
                 </div>
-                <h3 className="text-2xl font-semibold text-foreground">Building Tomorrow's Infrastructure</h3>
-                <p className="text-muted-foreground">Empowering the next generation of civil engineers</p>
-              </div>
+              )}
+              <div className="absolute inset-0 bg-gradient-to-t from-background/50 via-background/10 to-transparent" />
+            </div>
+
+            <div className="mt-6 grid grid-cols-3 gap-4 text-sm text-muted-foreground">
+              {["Global Network", "Professional Development", "Innovation Focus"].map((item) => (
+                <div key={item} className="flex items-center gap-2 rounded-full border border-secondary/40 bg-background/70 px-4 py-2 backdrop-blur">
+                  <div className="h-2 w-2 rounded-full bg-accent" />
+                  <span>{item}</span>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/components/magazine-section.tsx
+++ b/components/magazine-section.tsx
@@ -69,9 +69,6 @@ export async function MagazineSection() {
 
               return (
                 <Card key={publication.id} className="relative group hover:shadow-lg transition-shadow">
-                  {publication.is_featured && (
-                    <Badge className="absolute top-4 right-4 bg-accent text-accent-foreground">Featured</Badge>
-                  )}
                   <CardHeader>
                     <div
                       className={`relative overflow-hidden rounded-lg mb-4 ${


### PR DESCRIPTION
## Summary
- render uploaded hero artwork in the landing hero and refresh the supporting layout
- redesign the about section with mission and vision cards plus highlight imagery
- remove the featured badge treatment from magazine cards while keeping functionality intact

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e467f664832f9bde9db18f0b9435