### PR TITLE
Update home about and board sections

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import { AboutSection } from "@/components/about-section"
 import { BoardSection } from "@/components/board-section"
 import { MagazineSection } from "@/components/magazine-section"
 import { EventsSection } from "@/components/events-section"
-import { CommitteesSection } from "@/components/committees-section"
 import { ContactSection } from "@/components/contact-section"
 import { Footer } from "@/components/footer"
 
@@ -17,7 +16,6 @@ export default function HomePage() {
       <BoardSection />
       <MagazineSection />
       <EventsSection />
-      <CommitteesSection />
       <ContactSection />
       <Footer />
     </main>

--- a/components/about-section.tsx
+++ b/components/about-section.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import Image from "next/image"
 import { useEffect, useState } from "react"
 
 import { Card, CardContent } from "@/components/ui/card"
@@ -76,93 +75,47 @@ export function AboutSection() {
   return (
     <section id="about" className="py-20 bg-secondary/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid items-start gap-12 lg:grid-cols-[1.1fr,0.9fr]">
-          <div className="space-y-10">
-            <div className="space-y-5">
-              <span className="inline-flex items-center gap-2 text-sm font-semibold text-accent">
-                <span className="h-px w-8 bg-accent" />
-                Who We Are
-              </span>
-              <h2 className="text-3xl md:text-4xl font-bold text-foreground leading-tight">{content.title}</h2>
-              <p className="text-lg text-muted-foreground leading-relaxed">{content.content}</p>
-            </div>
-
-            {hasMissionOrVision && (
-              <div className="grid gap-6 sm:grid-cols-2">
-                {missionStatement && (
-                  <Card className="h-full border-none bg-background/80 shadow-lg shadow-secondary/20 ring-1 ring-secondary/30">
-                    <CardContent className="flex h-full flex-col gap-3 p-6">
-                      <h3 className="text-xl font-semibold text-foreground">Our Mission</h3>
-                      <p className="text-sm text-muted-foreground leading-relaxed">{missionStatement}</p>
-                    </CardContent>
-                  </Card>
-                )}
-
-                {visionStatement && (
-                  <Card className="h-full border-none bg-background/80 shadow-lg shadow-secondary/20 ring-1 ring-secondary/30">
-                    <CardContent className="flex h-full flex-col gap-3 p-6">
-                      <h3 className="text-xl font-semibold text-foreground">Our Vision</h3>
-                      <p className="text-sm text-muted-foreground leading-relaxed">{visionStatement}</p>
-                    </CardContent>
-                  </Card>
-                )}
-              </div>
-            )}
-
-            <div className="grid grid-cols-2 gap-4 sm:max-w-xl">
-              {highlights.map((highlight) => (
-                <Card key={highlight.label} className="border-none bg-secondary/40 backdrop-blur">
-                  <CardContent className="p-6">
-                    <div className="text-3xl font-bold text-foreground">{highlight.value}</div>
-                    <div className="text-sm text-muted-foreground">{highlight.label}</div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
+        <div className="space-y-10">
+          <div className="space-y-5">
+            <span className="inline-flex items-center gap-2 text-sm font-semibold text-accent">
+              <span className="h-px w-8 bg-accent" />
+              Who We Are
+            </span>
+            <h2 className="text-3xl md:text-4xl font-bold text-foreground leading-tight">{content.title}</h2>
+            <p className="text-lg text-muted-foreground leading-relaxed">{content.content}</p>
           </div>
 
-          <div className="space-y-8">
-            <div className="relative aspect-[4/5] overflow-hidden rounded-3xl border border-secondary/40 bg-gradient-to-br from-secondary/20 via-primary/10 to-accent/20 shadow-xl">
-              {content.image_url ? (
-                <Image
-                  src={content.image_url}
-                  alt={content.title}
-                  fill
-                  className="object-cover"
-                  sizes="(min-width: 1024px) 28rem, 100vw"
-                />
-              ) : (
-                <div className="flex h-full w-full items-center justify-center bg-secondary/20 px-8 text-center">
-                  <div className="space-y-3">
-                    <h3 className="text-2xl font-semibold text-foreground">A Global Community</h3>
-                    <p className="text-muted-foreground text-sm">
-                      Students, educators, and professionals collaborating to shape the future of civil engineering.
-                    </p>
-                  </div>
-                </div>
+          {hasMissionOrVision && (
+            <div className="grid gap-6 sm:grid-cols-2">
+              {missionStatement && (
+                <Card className="h-full border-none bg-background/80 shadow-lg shadow-secondary/20 ring-1 ring-secondary/30">
+                  <CardContent className="flex h-full flex-col gap-3 p-6">
+                    <h3 className="text-xl font-semibold text-foreground">Our Mission</h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">{missionStatement}</p>
+                  </CardContent>
+                </Card>
               )}
-              <div className="absolute inset-0 bg-gradient-to-t from-background/60 via-transparent to-transparent" />
-            </div>
 
-            <Card className="border-none bg-background/90 shadow-xl shadow-secondary/20 ring-1 ring-secondary/30">
-              <CardContent className="space-y-4 p-6">
-                <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">What we build together</p>
-                <ul className="space-y-2 text-sm text-muted-foreground">
-                  <li className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-accent" />
-                    Global exchange programs and study visits
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-accent" />
-                    Professional mentorship and lifelong networks
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-accent" />
-                    Hands-on projects advancing sustainable infrastructure
-                  </li>
-                </ul>
-              </CardContent>
-            </Card>
+              {visionStatement && (
+                <Card className="h-full border-none bg-background/80 shadow-lg shadow-secondary/20 ring-1 ring-secondary/30">
+                  <CardContent className="flex h-full flex-col gap-3 p-6">
+                    <h3 className="text-xl font-semibold text-foreground">Our Vision</h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">{visionStatement}</p>
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-4 sm:max-w-xl">
+            {highlights.map((highlight) => (
+              <Card key={highlight.label} className="border-none bg-secondary/40 backdrop-blur">
+                <CardContent className="p-6">
+                  <div className="text-3xl font-bold text-foreground">{highlight.value}</div>
+                  <div className="text-sm text-muted-foreground">{highlight.label}</div>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         </div>
 

--- a/components/board-section.tsx
+++ b/components/board-section.tsx
@@ -45,11 +45,8 @@ export function BoardSection() {
       <section id="board" className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">Board of Directors</h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Meet the distinguished leaders guiding IACES towards excellence in civil engineering education and global
-              collaboration.
-            </p>
+            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">General Board</h2>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">Meet with our General Board.</p>
           </div>
           <div className="flex justify-center">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
@@ -64,11 +61,8 @@ export function BoardSection() {
       <section id="board" className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">Board of Directors</h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Meet the distinguished leaders guiding IACES towards excellence in civil engineering education and global
-              collaboration.
-            </p>
+            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">General Board</h2>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">Meet with our General Board.</p>
           </div>
           <div className="text-center">
             <p className="text-muted-foreground">Board member information will be available soon.</p>
@@ -82,14 +76,11 @@ export function BoardSection() {
     <section id="board" className="py-20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">Board of Directors</h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-            Meet the distinguished leaders guiding IACES towards excellence in civil engineering education and global
-            collaboration.
-          </p>
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">General Board</h2>
+          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">Meet with our General Board.</p>
         </div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+        <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-8">
           {boardMembers.map((member) => (
             <Card key={member.id} className="text-center">
               <CardContent className="p-6">


### PR DESCRIPTION
## Summary
- remove the local committees section from the homepage
- simplify the About IACES section by removing the image and supplemental list
- rename the leadership area to General Board and support five profiles per row

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e75cae5c832f8536941462b41dfb