### PR TITLE
Show event images and refresh About section highlights

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image"
 import Link from "next/link"
 import { Calendar, Clock, MapPin } from "lucide-react"
 
@@ -8,6 +9,16 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { getEvents } from "@/lib/data/events"
 import { formatEventDate, isExternalUrl, splitEventsByTime } from "@/lib/event-utils"
+import type { EventItem } from "@/lib/types"
+
+function getEventImageSrc(event: EventItem): string {
+  if (event.image_url && event.image_url.trim().length > 0) {
+    return event.image_url
+  }
+
+  const encodedTitle = encodeURIComponent(event.title)
+  return `/placeholder.svg?height=240&width=384&text=${encodedTitle}`
+}
 
 export default async function EventsPage() {
   const events = await getEvents()
@@ -53,13 +64,23 @@ export default async function EventsPage() {
                 upcoming.map((event) => {
                   const isExternal = event.registration_url ? isExternalUrl(event.registration_url) : false
                   const hasRegistration = Boolean(event.registration_url)
+                  const imageSrc = getEventImageSrc(event)
 
                   return (
-                    <Card key={event.id} className="relative">
+                    <Card key={event.id} className="relative flex h-full flex-col overflow-hidden">
+                      <div className="relative aspect-[16/9] w-full">
+                        <Image
+                          src={imageSrc}
+                          alt={`${event.title} visual`}
+                          fill
+                          className="object-cover"
+                          sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                        />
+                      </div>
                       <CardHeader>
                         <CardTitle className="text-lg">{event.title}</CardTitle>
                       </CardHeader>
-                      <CardContent className="space-y-4">
+                      <CardContent className="flex flex-1 flex-col space-y-4">
                         {event.description && (
                           <p className="text-muted-foreground text-sm leading-relaxed">{event.description}</p>
                         )}
@@ -77,25 +98,27 @@ export default async function EventsPage() {
                           )}
                         </div>
 
-                        {hasRegistration ? (
-                          <Button
-                            asChild
-                            size="sm"
-                            variant="outline"
-                            className="w-full border border-input bg-white text-black hover:bg-muted"
-                          >
-                            <Link
-                              href={event.registration_url!}
-                              {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                        <div className="mt-auto">
+                          {hasRegistration ? (
+                            <Button
+                              asChild
+                              size="sm"
+                              variant="outline"
+                              className="w-full border border-input bg-white text-black hover:bg-muted"
                             >
-                              {event.registration_url?.startsWith("mailto:") ? "Contact Organizer" : "Register Now"}
-                            </Link>
-                          </Button>
-                        ) : (
-                          <div className="text-xs text-center text-muted-foreground">
-                            Registration details coming soon.
-                          </div>
-                        )}
+                              <Link
+                                href={event.registration_url!}
+                                {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                              >
+                                {event.registration_url?.startsWith("mailto:") ? "Contact Organizer" : "Register Now"}
+                              </Link>
+                            </Button>
+                          ) : (
+                            <div className="text-xs text-center text-muted-foreground">
+                              Registration details coming soon.
+                            </div>
+                          )}
+                        </div>
                       </CardContent>
                     </Card>
                   )
@@ -120,9 +143,19 @@ export default async function EventsPage() {
                 past.map((event) => {
                   const isExternal = event.registration_url ? isExternalUrl(event.registration_url) : false
                   const hasLink = Boolean(event.registration_url)
+                  const imageSrc = getEventImageSrc(event)
 
                   return (
-                    <Card key={event.id} className="opacity-90">
+                    <Card key={event.id} className="flex h-full flex-col overflow-hidden opacity-90">
+                      <div className="relative aspect-[16/9] w-full">
+                        <Image
+                          src={imageSrc}
+                          alt={`${event.title} visual`}
+                          fill
+                          className="object-cover"
+                          sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                        />
+                      </div>
                       <CardHeader>
                         <div className="flex items-center justify-between">
                           <CardTitle className="text-lg">{event.title}</CardTitle>
@@ -132,7 +165,7 @@ export default async function EventsPage() {
                           </Badge>
                         </div>
                       </CardHeader>
-                      <CardContent className="space-y-4">
+                      <CardContent className="flex flex-1 flex-col space-y-4">
                         {event.description && (
                           <p className="text-muted-foreground text-sm leading-relaxed">{event.description}</p>
                         )}
@@ -150,18 +183,20 @@ export default async function EventsPage() {
                           )}
                         </div>
 
-                        {hasLink ? (
-                          <Button asChild className="w-full bg-neutral-800 text-neutral-200 hover:bg-neutral-700" size="sm">
-                            <Link
-                              href={event.registration_url!}
-                              {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-                            >
-                              {event.registration_url?.startsWith("mailto:") ? "Request Details" : "View Details"}
-                            </Link>
-                          </Button>
-                        ) : (
-                          <div className="text-xs text-center text-muted-foreground">No additional resources available.</div>
-                        )}
+                        <div className="mt-auto">
+                          {hasLink ? (
+                            <Button asChild className="w-full bg-neutral-800 text-neutral-200 hover:bg-neutral-700" size="sm">
+                              <Link
+                                href={event.registration_url!}
+                                {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                              >
+                                {event.registration_url?.startsWith("mailto:") ? "Request Details" : "View Details"}
+                              </Link>
+                            </Button>
+                          ) : (
+                            <div className="text-xs text-center text-muted-foreground">No additional resources available.</div>
+                          )}
+                        </div>
                       </CardContent>
                     </Card>
                   )

--- a/components/about-section.tsx
+++ b/components/about-section.tsx
@@ -8,20 +8,16 @@ import { fallbackAboutContent } from "@/lib/fallback-data"
 
 const highlights = [
   {
-    label: "Countries",
-    value: "50+",
+    emphasis: "15+ Countries",
   },
   {
-    label: "Members",
-    value: "10K+",
+    emphasis: "3000+ Members",
   },
   {
-    label: "Universities",
-    value: "200+",
+    emphasis: "20+ Universities",
   },
   {
-    label: "Years",
-    value: "25",
+    emphasis: "Since 1989",
   },
 ]
 
@@ -107,12 +103,13 @@ export function AboutSection() {
             </div>
           )}
 
-          <div className="grid grid-cols-2 gap-4 sm:max-w-xl">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {highlights.map((highlight) => (
-              <Card key={highlight.label} className="border-none bg-secondary/40 backdrop-blur">
+              <Card key={highlight.emphasis} className="border-none bg-secondary/40 backdrop-blur">
                 <CardContent className="p-6">
-                  <div className="text-3xl font-bold text-foreground">{highlight.value}</div>
-                  <div className="text-sm text-muted-foreground">{highlight.label}</div>
+                  <div className="text-2xl font-semibold text-foreground md:text-3xl">
+                    {highlight.emphasis}
+                  </div>
                 </CardContent>
               </Card>
             ))}

--- a/components/events-section.tsx
+++ b/components/events-section.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image"
 import Link from "next/link"
 import { Calendar, Clock, MapPin } from "lucide-react"
 
@@ -20,6 +21,15 @@ function getActionLabel(event: EventItem, isUpcoming: boolean): string {
   }
 
   return isUpcoming ? "Register Now" : "View Details"
+}
+
+function getEventImageSrc(event: EventItem): string {
+  if (event.image_url && event.image_url.trim().length > 0) {
+    return event.image_url
+  }
+
+  const encodedTitle = encodeURIComponent(event.title)
+  return `/placeholder.svg?height=240&width=384&text=${encodedTitle}`
 }
 
 export async function EventsSection() {
@@ -49,13 +59,23 @@ export async function EventsSection() {
               const actionLabel = getActionLabel(event, true)
               const isDisabled = !event.registration_url
               const isExternal = event.registration_url ? isExternalUrl(event.registration_url) : false
+              const imageSrc = getEventImageSrc(event)
 
               return (
-                <Card key={event.id}>
+                <Card key={event.id} className="flex h-full flex-col overflow-hidden">
+                  <div className="relative aspect-[16/9] w-full">
+                    <Image
+                      src={imageSrc}
+                      alt={`${event.title} visual`}
+                      fill
+                      className="object-cover"
+                      sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                    />
+                  </div>
                   <CardHeader>
                     <CardTitle className="text-lg">{event.title}</CardTitle>
                   </CardHeader>
-                  <CardContent className="space-y-4">
+                  <CardContent className="flex flex-1 flex-col space-y-4">
                     {event.description && (
                       <p className="text-muted-foreground text-sm leading-relaxed">{event.description}</p>
                     )}
@@ -73,23 +93,25 @@ export async function EventsSection() {
                       )}
                     </div>
 
-                    {isDisabled ? (
-                      <div className="text-xs text-center text-muted-foreground">Registration details coming soon.</div>
-                    ) : (
-                      <Button
-                        asChild
-                        size="sm"
-                        variant="outline"
-                        className="w-full border border-input bg-primary text-primary-foreground hover:bg-primary/90"
-                      >
-                        <Link
-                          href={event.registration_url!}
-                          {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                    <div className="mt-auto">
+                      {isDisabled ? (
+                        <div className="text-xs text-center text-muted-foreground">Registration details coming soon.</div>
+                      ) : (
+                        <Button
+                          asChild
+                          size="sm"
+                          variant="outline"
+                          className="w-full border border-input bg-primary text-primary-foreground hover:bg-primary/90"
                         >
-                          {actionLabel}
-                        </Link>
-                      </Button>
-                    )}
+                          <Link
+                            href={event.registration_url!}
+                            {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                          >
+                            {actionLabel}
+                          </Link>
+                        </Button>
+                      )}
+                    </div>
                   </CardContent>
                 </Card>
               )
@@ -116,13 +138,23 @@ export async function EventsSection() {
               const actionLabel = getActionLabel(event, false)
               const isDisabled = !event.registration_url
               const isExternal = event.registration_url ? isExternalUrl(event.registration_url) : false
+              const imageSrc = getEventImageSrc(event)
 
               return (
-                <Card key={event.id} className="opacity-90">
+                <Card key={event.id} className="flex h-full flex-col overflow-hidden opacity-90">
+                  <div className="relative aspect-[16/9] w-full">
+                    <Image
+                      src={imageSrc}
+                      alt={`${event.title} visual`}
+                      fill
+                      className="object-cover"
+                      sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                    />
+                  </div>
                   <CardHeader>
                     <CardTitle className="text-lg">{event.title}</CardTitle>
                   </CardHeader>
-                  <CardContent className="space-y-4">
+                  <CardContent className="flex flex-1 flex-col space-y-4">
                     {event.description && (
                       <p className="text-muted-foreground text-sm leading-relaxed">{event.description}</p>
                     )}
@@ -140,18 +172,20 @@ export async function EventsSection() {
                       )}
                     </div>
 
-                    {isDisabled ? (
-                      <div className="text-xs text-center text-muted-foreground">No additional resources available.</div>
-                    ) : (
-                      <Button asChild size="sm" className="w-full bg-neutral-800 text-neutral-200 hover:bg-neutral-700">
-                        <Link
-                          href={event.registration_url!}
-                          {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-                        >
-                          {actionLabel}
-                        </Link>
-                      </Button>
-                    )}
+                    <div className="mt-auto">
+                      {isDisabled ? (
+                        <div className="text-xs text-center text-muted-foreground">No additional resources available.</div>
+                      ) : (
+                        <Button asChild size="sm" className="w-full bg-neutral-800 text-neutral-200 hover:bg-neutral-700">
+                          <Link
+                            href={event.registration_url!}
+                            {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                          >
+                            {actionLabel}
+                          </Link>
+                        </Button>
+                      )}
+                    </div>
                   </CardContent>
                 </Card>
               )


### PR DESCRIPTION
## Summary
- display event imagery on the homepage and events listing with graceful fallbacks for missing assets
- align event card layouts so calls-to-action stay anchored beneath descriptions
- update About IACES highlight tiles to show the latest metrics in a single four-column row

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e9d2d88c832f874104984b80fee8