### PR TITLE
Enable saving and surfacing site settings

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,32 +1,146 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { ContentEditor, TextField, TextAreaField, SwitchField } from "@/components/admin/content-editor"
 import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/hooks/use-toast"
+import { isSupabaseEnvConfigured } from "@/lib/supabase/config"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+
+interface AdminSiteSettings {
+  siteTitle: string
+  siteDescription: string
+  contactEmail: string
+  contactAddress: string
+  socialFacebook: string
+  socialTwitter: string
+  socialLinkedin: string
+  maintenanceMode: boolean
+  allowRegistrations: boolean
+  enableAnalytics: boolean
+}
+
+const DEFAULT_SETTINGS: AdminSiteSettings = {
+  siteTitle: "IACES - International Association of Civil Engineering Students",
+  siteDescription: "Connecting civil engineering students worldwide",
+  contactEmail: "info@iaces.network",
+  contactAddress: "123 Technology Drive, Innovation City, IC 12345",
+  socialFacebook: "https://facebook.com/iaces",
+  socialTwitter: "https://twitter.com/iaces",
+  socialLinkedin: "https://linkedin.com/company/iaces",
+  maintenanceMode: false,
+  allowRegistrations: true,
+  enableAnalytics: true,
+}
 
 export default function SettingsAdminPage() {
-  const [siteSettings, setSiteSettings] = useState({
-    siteTitle: "IACES - International Association of Computer Engineering Students",
-    siteDescription: "Connecting computer engineering students worldwide",
-    contactEmail: "info@iaces.network",
-    address: "123 Technology Drive, Innovation City, IC 12345",
-    socialFacebook: "https://facebook.com/iaces",
-    socialTwitter: "https://twitter.com/iaces",
-    socialLinkedin: "https://linkedin.com/company/iaces",
-    maintenanceMode: false,
-    allowRegistrations: true,
-    enableAnalytics: true,
-  })
-
+  const [siteSettings, setSiteSettings] = useState<AdminSiteSettings>(() => ({ ...DEFAULT_SETTINGS }))
+  const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const { toast } = useToast()
+  const isSupabaseConfigured = isSupabaseEnvConfigured()
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const response = await fetch("/api/settings")
+        if (!response.ok) {
+          throw new Error(`Failed to load settings: ${response.status}`)
+        }
+
+        const data = await response.json()
+        setSiteSettings({
+          siteTitle: data.site_title ?? DEFAULT_SETTINGS.siteTitle,
+          siteDescription: data.site_description ?? DEFAULT_SETTINGS.siteDescription,
+          contactEmail: data.contact_email ?? DEFAULT_SETTINGS.contactEmail,
+          contactAddress: data.contact_address ?? DEFAULT_SETTINGS.contactAddress,
+          socialFacebook: data.social_facebook ?? DEFAULT_SETTINGS.socialFacebook,
+          socialTwitter: data.social_twitter ?? DEFAULT_SETTINGS.socialTwitter,
+          socialLinkedin: data.social_linkedin ?? DEFAULT_SETTINGS.socialLinkedin,
+          maintenanceMode: Boolean(data.maintenance_mode),
+          allowRegistrations: Boolean(data.allow_registrations),
+          enableAnalytics: Boolean(data.enable_analytics),
+        })
+      } catch (error) {
+        console.error("Error loading site settings:", error)
+        toast({
+          title: "Failed to load settings",
+          description: "Showing fallback values. Please try again later.",
+          variant: "destructive",
+        })
+        setSiteSettings({ ...DEFAULT_SETTINGS })
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchSettings()
+  }, [toast])
 
   const handleSave = async () => {
+    if (!siteSettings.siteTitle || !siteSettings.siteTitle.trim()) {
+      toast({
+        title: "Site title is required",
+        description: "Please provide a title for your website before saving.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    if (!isSupabaseConfigured) {
+      toast({
+        title: "Supabase configuration required",
+        description: "Connect Supabase to enable saving settings.",
+        variant: "destructive",
+      })
+      return
+    }
+
     setSaving(true)
     try {
-      await new Promise((resolve) => setTimeout(resolve, 400))
-      console.log("Saving site settings:", siteSettings)
+      const response = await fetch("/api/settings", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          siteTitle: siteSettings.siteTitle,
+          siteDescription: siteSettings.siteDescription,
+          contactEmail: siteSettings.contactEmail,
+          contactAddress: siteSettings.contactAddress,
+          socialFacebook: siteSettings.socialFacebook,
+          socialTwitter: siteSettings.socialTwitter,
+          socialLinkedin: siteSettings.socialLinkedin,
+          maintenanceMode: siteSettings.maintenanceMode,
+          allowRegistrations: siteSettings.allowRegistrations,
+          enableAnalytics: siteSettings.enableAnalytics,
+        }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null)
+        toast({
+          title: "Error saving settings",
+          description: errorData?.error ?? "We couldn't save your settings. Please try again.",
+          variant: "destructive",
+        })
+        return
+      }
+
+      const data = await response.json()
+      setSiteSettings({
+        siteTitle: data.site_title ?? siteSettings.siteTitle,
+        siteDescription: data.site_description ?? siteSettings.siteDescription,
+        contactEmail: data.contact_email ?? siteSettings.contactEmail,
+        contactAddress: data.contact_address ?? siteSettings.contactAddress,
+        socialFacebook: data.social_facebook ?? siteSettings.socialFacebook,
+        socialTwitter: data.social_twitter ?? siteSettings.socialTwitter,
+        socialLinkedin: data.social_linkedin ?? siteSettings.socialLinkedin,
+        maintenanceMode: Boolean(data.maintenance_mode),
+        allowRegistrations: Boolean(data.allow_registrations),
+        enableAnalytics: Boolean(data.enable_analytics),
+      })
+
       toast({
         title: "Settings saved",
         description: "Your configuration changes have been stored.",
@@ -43,16 +157,38 @@ export default function SettingsAdminPage() {
     }
   }
 
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent mx-auto"></div>
+          <p className="text-muted-foreground mt-4">Loading site settings...</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <ContentEditor
       title="Site Settings"
       backUrl="/admin"
       onSave={handleSave}
       isSaving={saving}
+      saveDisabled={!isSupabaseConfigured}
       saveLabel="Save Settings"
       description="Configure global preferences, contact details, and system behaviour."
     >
       <div className="space-y-8">
+        {!isSupabaseConfigured && (
+          <Alert variant="destructive">
+            <AlertTitle>Editing is temporarily disabled</AlertTitle>
+            <AlertDescription>
+              Supabase credentials are not configured. The settings shown below are fallback values and cannot be saved until
+              Supabase is connected.
+            </AlertDescription>
+          </Alert>
+        )}
+
         {/* General Settings */}
         <div>
           <h3 className="text-lg font-semibold text-foreground mb-4">General Settings</h3>
@@ -94,8 +230,8 @@ export default function SettingsAdminPage() {
             <div className="md:col-span-2">
               <TextAreaField
                 label="Address"
-                value={siteSettings.address}
-                onChange={(value) => setSiteSettings((prev) => ({ ...prev, address: value }))}
+                value={siteSettings.contactAddress}
+                onChange={(value) => setSiteSettings((prev) => ({ ...prev, contactAddress: value }))}
                 placeholder="Enter full address"
                 description="Physical address of the organization"
                 rows={2}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,158 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { revalidatePath } from "next/cache"
+
+import { ContentService } from "@/lib/content-service"
+import { fallbackSiteSettings } from "@/lib/fallback-data"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
+
+const DEFAULT_SETTINGS = {
+  site_title: fallbackSiteSettings.site_title,
+  site_description: fallbackSiteSettings.site_description,
+  contact_email: fallbackSiteSettings.contact_email,
+  contact_address: fallbackSiteSettings.contact_address,
+  social_facebook: fallbackSiteSettings.social_facebook,
+  social_twitter: fallbackSiteSettings.social_twitter,
+  social_linkedin: fallbackSiteSettings.social_linkedin,
+  maintenance_mode: fallbackSiteSettings.maintenance_mode === "true",
+  allow_registrations: fallbackSiteSettings.allow_registrations === "true",
+  enable_analytics: fallbackSiteSettings.enable_analytics === "true",
+}
+
+type SiteSettingsResponse = typeof DEFAULT_SETTINGS
+
+type SiteSettingsPayload = {
+  siteTitle: unknown
+  siteDescription: unknown
+  contactEmail: unknown
+  contactAddress: unknown
+  socialFacebook: unknown
+  socialTwitter: unknown
+  socialLinkedin: unknown
+  maintenanceMode: unknown
+  allowRegistrations: unknown
+  enableAnalytics: unknown
+}
+
+function toBoolean(value: unknown, defaultValue: boolean): boolean {
+  if (typeof value === "boolean") {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase()
+    if (["true", "1", "yes", "on"].includes(normalized)) {
+      return true
+    }
+    if (["false", "0", "no", "off"].includes(normalized)) {
+      return false
+    }
+  }
+
+  return defaultValue
+}
+
+function toNullableString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length === 0 ? null : trimmed
+}
+
+async function readSiteSettings(): Promise<SiteSettingsResponse> {
+  const rawSettings = await ContentService.getSiteSettings()
+
+  return {
+    site_title: rawSettings.site_title ?? DEFAULT_SETTINGS.site_title,
+    site_description: rawSettings.site_description ?? DEFAULT_SETTINGS.site_description,
+    contact_email: rawSettings.contact_email ?? DEFAULT_SETTINGS.contact_email,
+    contact_address: rawSettings.contact_address ?? DEFAULT_SETTINGS.contact_address,
+    social_facebook: rawSettings.social_facebook ?? DEFAULT_SETTINGS.social_facebook,
+    social_twitter: rawSettings.social_twitter ?? DEFAULT_SETTINGS.social_twitter,
+    social_linkedin: rawSettings.social_linkedin ?? DEFAULT_SETTINGS.social_linkedin,
+    maintenance_mode: toBoolean(rawSettings.maintenance_mode, DEFAULT_SETTINGS.maintenance_mode),
+    allow_registrations: toBoolean(rawSettings.allow_registrations, DEFAULT_SETTINGS.allow_registrations),
+    enable_analytics: toBoolean(rawSettings.enable_analytics, DEFAULT_SETTINGS.enable_analytics),
+  }
+}
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const settings = await readSiteSettings()
+    return NextResponse.json(settings)
+  } catch (error) {
+    console.error("Error loading site settings:", error)
+    return NextResponse.json({ error: "Failed to load site settings" }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    if (!isSupabaseConfigured()) {
+      return NextResponse.json({ error: "Supabase is not configured" }, { status: 503 })
+    }
+
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const body = (await request.json()) as SiteSettingsPayload
+
+    const siteTitle = toNullableString(body.siteTitle)
+    if (!siteTitle) {
+      return NextResponse.json({ error: "Site title is required" }, { status: 400 })
+    }
+
+    const siteDescription = toNullableString(body.siteDescription)
+    const contactEmail = toNullableString(body.contactEmail)
+    const contactAddress = toNullableString(body.contactAddress)
+    const socialFacebook = toNullableString(body.socialFacebook)
+    const socialTwitter = toNullableString(body.socialTwitter)
+    const socialLinkedin = toNullableString(body.socialLinkedin)
+
+    const maintenanceMode = toBoolean(body.maintenanceMode, DEFAULT_SETTINGS.maintenance_mode)
+    const allowRegistrations = toBoolean(body.allowRegistrations, DEFAULT_SETTINGS.allow_registrations)
+    const enableAnalytics = toBoolean(body.enableAnalytics, DEFAULT_SETTINGS.enable_analytics)
+
+    const updates = [
+      { key: "site_title", value: siteTitle },
+      { key: "site_description", value: siteDescription },
+      { key: "contact_email", value: contactEmail },
+      { key: "contact_address", value: contactAddress },
+      { key: "social_facebook", value: socialFacebook },
+      { key: "social_twitter", value: socialTwitter },
+      { key: "social_linkedin", value: socialLinkedin },
+      { key: "maintenance_mode", value: maintenanceMode ? "true" : "false" },
+      { key: "allow_registrations", value: allowRegistrations ? "true" : "false" },
+      { key: "enable_analytics", value: enableAnalytics ? "true" : "false" },
+    ].map((setting) => ({
+      ...setting,
+      user_id: user.id,
+      updated_at: new Date().toISOString(),
+    }))
+
+    const { error } = await supabase.from("site_settings").upsert(updates, { onConflict: "key" })
+
+    if (error) {
+      console.error("Error updating site settings:", error)
+      return NextResponse.json({ error: "Failed to save site settings" }, { status: 500 })
+    }
+
+    revalidatePath("/", "layout")
+    revalidatePath("/")
+
+    const updatedSettings = await readSiteSettings()
+    return NextResponse.json(updatedSettings)
+  } catch (error) {
+    console.error("Error saving site settings:", error)
+    return NextResponse.json({ error: "Failed to save site settings" }, { status: 500 })
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,14 +6,22 @@ import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
 
 import { SupabaseListener } from "@/components/auth/supabase-listener"
+import { ContentService } from "@/lib/content-service"
 
 import "./globals.css"
 
-export const metadata: Metadata = {
-  title: "IACES - International Association of Civil Engineering Students",
-  description:
-    "Connecting civil engineering students worldwide through education, collaboration, and professional development opportunities.",
-  generator: "v0.app",
+export async function generateMetadata(): Promise<Metadata> {
+  const siteSettings = await ContentService.getSiteSettings()
+  const title = siteSettings.site_title ?? "IACES - International Association of Civil Engineering Students"
+  const description =
+    siteSettings.site_description ??
+    "Connecting civil engineering students worldwide through education, collaboration, and professional development opportunities."
+
+  return {
+    title,
+    description,
+    generator: "v0.app",
+  }
 }
 
 export default function RootLayout({

--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -11,12 +11,36 @@ import { Label } from "@/components/ui/label"
 import { Mail, MapPin } from "lucide-react"
 
 export function ContactSection() {
+  const [siteSettings, setSiteSettings] = useState({
+    contactEmail: "info@iaces.network",
+    contactAddress: "123 Technology Drive\nInnovation City, IC 12345",
+  })
   const [formData, setFormData] = useState({
     name: "",
     email: "",
     subject: "",
     message: "",
   })
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const response = await fetch("/api/settings")
+        if (!response.ok) {
+          return
+        }
+        const data = await response.json()
+        setSiteSettings((prev) => ({
+          contactEmail: data.contact_email ?? prev.contactEmail,
+          contactAddress: data.contact_address ?? prev.contactAddress,
+        }))
+      } catch (error) {
+        console.error("Failed to load site settings for contact section:", error)
+      }
+    }
+
+    fetchSettings()
+  }, [])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -52,11 +76,7 @@ export function ContactSection() {
                   <MapPin className="w-5 h-5 text-accent mt-0.5" />
                   <div>
                     <p className="font-medium text-foreground">Address</p>
-                    <p className="text-muted-foreground text-sm">
-                      123 Technology Drive
-                      <br />
-                      Innovation City, IC 12345
-                    </p>
+                    <p className="text-muted-foreground text-sm whitespace-pre-line">{siteSettings.contactAddress}</p>
                   </div>
                 </div>
 
@@ -64,7 +84,7 @@ export function ContactSection() {
                   <Mail className="w-5 h-5 text-accent mt-0.5" />
                   <div>
                     <p className="font-medium text-foreground">Email</p>
-                    <p className="text-muted-foreground text-sm">info@iaces.network</p>
+                    <p className="text-muted-foreground text-sm">{siteSettings.contactEmail}</p>
                   </div>
                 </div>
               </CardContent>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,27 +1,42 @@
 import Link from "next/link"
 import { Linkedin, Twitter, Mail } from "lucide-react"
 
-export function Footer() {
+import { ContentService } from "@/lib/content-service"
+
+export async function Footer() {
+  const siteSettings = await ContentService.getSiteSettings()
+  const siteTitle = siteSettings.site_title ?? "IACES"
+  const siteDescription =
+    siteSettings.site_description ??
+    "International Association of Civil Engineering Students - Connecting future engineers worldwide."
+  const contactEmail = siteSettings.contact_email ?? "info@iaces.network"
+  const contactAddress = siteSettings.contact_address ?? "123 Technology Drive\nInnovation City, IC 12345"
+
+  const socialLinks = [
+    { href: siteSettings.social_twitter, icon: Twitter },
+    { href: siteSettings.social_linkedin, icon: Linkedin },
+    { href: contactEmail ? `mailto:${contactEmail}` : null, icon: Mail },
+  ].filter((link) => typeof link.href === "string" && link.href.trim().length > 0) as {
+    href: string
+    icon: typeof Twitter
+  }[]
+
   return (
     <footer className="bg-primary text-primary-foreground">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid md:grid-cols-4 gap-8">
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold">IACES</h3>
-            <p className="text-sm text-primary-foreground/80">
-              International Association of Civil Engineering Students - Connecting future engineers worldwide.
-            </p>
-            <div className="flex space-x-4">
-              <Link href="#" className="text-primary-foreground/80 hover:text-primary-foreground">
-                <Twitter className="w-5 h-5" />
-              </Link>
-              <Link href="#" className="text-primary-foreground/80 hover:text-primary-foreground">
-                <Linkedin className="w-5 h-5" />
-              </Link>
-              <Link href="#" className="text-primary-foreground/80 hover:text-primary-foreground">
-                <Mail className="w-5 h-5" />
-              </Link>
-            </div>
+            <h3 className="text-lg font-semibold">{siteTitle}</h3>
+            <p className="text-sm text-primary-foreground/80">{siteDescription}</p>
+            {socialLinks.length > 0 && (
+              <div className="flex space-x-4">
+                {socialLinks.map(({ href, icon: Icon }) => (
+                  <Link key={href} href={href} className="text-primary-foreground/80 hover:text-primary-foreground">
+                    <Icon className="w-5 h-5" />
+                  </Link>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="space-y-4">
@@ -63,15 +78,16 @@ export function Footer() {
           <div className="space-y-4">
             <h4 className="font-medium">Contact</h4>
             <div className="space-y-2 text-sm text-primary-foreground/80">
-              <p>123 Technology Drive</p>
-              <p>Innovation City, IC 12345</p>
-              <p>info@iaces.network</p>
+              <p className="whitespace-pre-line">{contactAddress}</p>
+              <p>{contactEmail}</p>
             </div>
           </div>
         </div>
 
         <div className="border-t border-primary-foreground/20 mt-8 pt-8 text-center text-sm text-primary-foreground/80">
-          <p>&copy; 2025 International Association of Civil Engineering Students. All rights reserved.</p>
+          <p>
+            &copy; 2025 {siteTitle}. All rights reserved.
+          </p>
         </div>
       </div>
     </footer>

--- a/lib/content-service.ts
+++ b/lib/content-service.ts
@@ -380,14 +380,21 @@ export class ContentService {
 
     const settings: Record<string, string> = { ...fallbackSiteSettings }
     data?.forEach((setting) => {
-      if (setting.key && setting.value) {
-        settings[setting.key] = setting.value
+      if (!setting?.key) {
+        return
       }
+
+      if (setting.value === null || setting.value === undefined) {
+        settings[setting.key] = ""
+        return
+      }
+
+      settings[setting.key] = setting.value
     })
     return settings
   }
 
-  static async updateSiteSetting(key: string, value: string, userId: string): Promise<boolean> {
+  static async updateSiteSetting(key: string, value: string | null, userId: string): Promise<boolean> {
     const supabase = await this.getSupabase()
     if (!supabase) {
       console.warn("Supabase unavailable - unable to update site settings.")

--- a/lib/fallback-data.ts
+++ b/lib/fallback-data.ts
@@ -221,9 +221,16 @@ export const fallbackLocalCommittees: LocalCommittee[] = [
 ]
 
 export const fallbackSiteSettings: Record<string, string> = {
+  site_title: "IACES - International Association of Civil Engineering Students",
+  site_description: "Connecting civil engineering students worldwide",
   contact_email: "info@iaces.network",
-  contact_phone: "+1 (555) 123-4567",
-  headquarters_city: "Innovation City",
+  contact_address: "123 Technology Drive, Innovation City, IC 12345",
+  social_facebook: "https://facebook.com/iaces",
+  social_twitter: "https://twitter.com/iaces",
+  social_linkedin: "https://linkedin.com/company/iaces",
+  maintenance_mode: "false",
+  allow_registrations: "true",
+  enable_analytics: "true",
 }
 
 export interface AdminEventFallback {


### PR DESCRIPTION
## Summary
- add a dynamic /api/settings endpoint to read and persist site settings in Supabase with sane fallbacks
- refactor the admin settings page to load and save data through the API and block writes when Supabase is unavailable
- read site settings on the public site for metadata, footer content, and contact details

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d927a5c8a4832f859cc06e176b6a89