### PR TITLE
Align homepage site settings with database

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,18 +6,27 @@ import { MagazineSection } from "@/components/magazine-section"
 import { EventsSection } from "@/components/events-section"
 import { ContactSection } from "@/components/contact-section"
 import { Footer } from "@/components/footer"
+import { ContentService } from "@/lib/content-service"
 
-export default function HomePage() {
+export default async function HomePage() {
+  const siteSettings = await ContentService.getSiteSettings()
+
   return (
     <main className="min-h-screen">
-      <Navigation />
-      <DynamicHeroSection />
+      <Navigation
+        siteTitle={siteSettings.site_title}
+        siteDescription={siteSettings.site_description}
+      />
+      <DynamicHeroSection siteSettings={siteSettings} />
       <AboutSection />
       <BoardSection />
       <MagazineSection />
       <EventsSection />
-      <ContactSection />
-      <Footer />
+      <ContactSection
+        contactEmail={siteSettings.contact_email}
+        contactAddress={siteSettings.contact_address}
+      />
+      <Footer siteSettings={siteSettings} />
     </main>
   )
 }

--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -10,17 +10,33 @@ import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { Mail, MapPin } from "lucide-react"
 
-export function ContactSection() {
-  const [siteSettings, setSiteSettings] = useState({
-    contactEmail: "info@iaces.network",
-    contactAddress: "123 Technology Drive\nInnovation City, IC 12345",
-  })
+type ContactSectionProps = {
+  contactEmail?: string | null
+  contactAddress?: string | null
+}
+
+const DEFAULT_CONTACT_EMAIL = "info@iaces.network"
+const DEFAULT_CONTACT_ADDRESS = "123 Technology Drive\nInnovation City, IC 12345"
+
+export function ContactSection({ contactEmail, contactAddress }: ContactSectionProps) {
+  const [siteSettings, setSiteSettings] = useState(() => ({
+    contactEmail: contactEmail?.trim() || DEFAULT_CONTACT_EMAIL,
+    contactAddress: contactAddress?.trim() || DEFAULT_CONTACT_ADDRESS,
+  }))
   const [formData, setFormData] = useState({
     name: "",
     email: "",
     subject: "",
     message: "",
   })
+
+  useEffect(() => {
+    setSiteSettings((prev) => ({
+      ...prev,
+      contactEmail: contactEmail?.trim() || DEFAULT_CONTACT_EMAIL,
+      contactAddress: contactAddress?.trim() || DEFAULT_CONTACT_ADDRESS,
+    }))
+  }, [contactEmail, contactAddress])
 
   useEffect(() => {
     const fetchSettings = async () => {
@@ -31,8 +47,8 @@ export function ContactSection() {
         }
         const data = await response.json()
         setSiteSettings((prev) => ({
-          contactEmail: data.contact_email ?? prev.contactEmail,
-          contactAddress: data.contact_address ?? prev.contactAddress,
+          contactEmail: data.contact_email?.trim() || prev.contactEmail,
+          contactAddress: data.contact_address?.trim() || prev.contactAddress,
         }))
       } catch (error) {
         console.error("Failed to load site settings for contact section:", error)

--- a/components/dynamic-hero-section.tsx
+++ b/components/dynamic-hero-section.tsx
@@ -6,6 +6,10 @@ import { ContentService } from "@/lib/content-service"
 import type { HeroContent } from "@/lib/types"
 import { ArrowRight, Compass, Globe2, Lightbulb, Users2 } from "lucide-react"
 
+type DynamicHeroSectionProps = {
+  siteSettings?: Record<string, string>
+}
+
 async function getHeroContent(): Promise<HeroContent | null> {
   try {
     return await ContentService.getActiveHeroContent()
@@ -15,12 +19,16 @@ async function getHeroContent(): Promise<HeroContent | null> {
   }
 }
 
-export async function DynamicHeroSection() {
+export async function DynamicHeroSection({ siteSettings }: DynamicHeroSectionProps) {
   const heroContent = await getHeroContent()
+  const fallbackTitle =
+    siteSettings?.site_title?.trim() || "International Association of Civil Engineering Students"
+  const fallbackDescription =
+    siteSettings?.site_description?.trim() ||
+    "Join a global community of civil engineering students and professionals dedicated to innovation, collaboration, and excellence in sustainable infrastructure development."
   const content = heroContent ?? {
-    title: "International Association of Civil Engineering Students",
-    description:
-      "Join a global community of civil engineering students and professionals dedicated to innovation, collaboration, and excellence in sustainable infrastructure development.",
+    title: fallbackTitle,
+    description: fallbackDescription,
     cta_text: "Learn More",
     cta_link: "#about",
   }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,18 +3,32 @@ import { Linkedin, Twitter, Mail } from "lucide-react"
 
 import { ContentService } from "@/lib/content-service"
 
-export async function Footer() {
-  const siteSettings = await ContentService.getSiteSettings()
-  const siteTitle = siteSettings.site_title ?? "IACES"
+type FooterProps = {
+  siteSettings?: Record<string, string>
+}
+
+export async function Footer({ siteSettings }: FooterProps) {
+  const resolvedSiteSettings = siteSettings ?? (await ContentService.getSiteSettings())
+  const siteTitleValue = resolvedSiteSettings.site_title
+  const siteDescriptionValue = resolvedSiteSettings.site_description
+  const contactEmailValue = resolvedSiteSettings.contact_email
+  const contactAddressValue = resolvedSiteSettings.contact_address
+
+  const siteTitle = siteTitleValue && siteTitleValue.trim().length > 0 ? siteTitleValue : "IACES"
   const siteDescription =
-    siteSettings.site_description ??
-    "International Association of Civil Engineering Students - Connecting future engineers worldwide."
-  const contactEmail = siteSettings.contact_email ?? "info@iaces.network"
-  const contactAddress = siteSettings.contact_address ?? "123 Technology Drive\nInnovation City, IC 12345"
+    siteDescriptionValue && siteDescriptionValue.trim().length > 0
+      ? siteDescriptionValue
+      : "International Association of Civil Engineering Students - Connecting future engineers worldwide."
+  const contactEmail =
+    contactEmailValue && contactEmailValue.trim().length > 0 ? contactEmailValue : "info@iaces.network"
+  const contactAddress =
+    contactAddressValue && contactAddressValue.trim().length > 0
+      ? contactAddressValue
+      : "123 Technology Drive\nInnovation City, IC 12345"
 
   const socialLinks = [
-    { href: siteSettings.social_twitter, icon: Twitter },
-    { href: siteSettings.social_linkedin, icon: Linkedin },
+    { href: resolvedSiteSettings.social_twitter, icon: Twitter },
+    { href: resolvedSiteSettings.social_linkedin, icon: Linkedin },
     { href: contactEmail ? `mailto:${contactEmail}` : null, icon: Mail },
   ].filter((link) => typeof link.href === "string" && link.href.trim().length > 0) as {
     href: string

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -7,23 +7,37 @@ import { Button } from "@/components/ui/button"
 import { UserMenu } from "@/components/auth/user-menu"
 import { Menu, X } from "lucide-react"
 
-export function Navigation() {
+type NavigationProps = {
+  siteTitle?: string | null
+  siteDescription?: string | null
+}
+
+export function Navigation({ siteTitle, siteDescription }: NavigationProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const resolvedSiteTitle = siteTitle?.trim() || "IACES - International Association of Civil Engineering Students"
+  const resolvedSiteDescription =
+    siteDescription?.trim() || "Connecting civil engineering students worldwide"
 
   return (
     <nav className="fixed top-0 w-full z-50 bg-background/80 backdrop-blur-md border-b border-border">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
-            <Link href="/" className="flex items-center">
+            <Link
+              href="/"
+              className="flex items-center"
+              aria-label={resolvedSiteTitle}
+              title={resolvedSiteDescription}
+            >
               <Image
                 src="/iaces-logo.png"
-                alt="IACES - International Association of Civil Engineering Students"
+                alt={resolvedSiteTitle}
                 width={120}
                 height={40}
                 className="h-10 w-auto"
                 priority
               />
+              <span className="sr-only">{resolvedSiteTitle}</span>
             </Link>
           </div>
 


### PR DESCRIPTION
## Summary
- load site settings on the homepage and pass them through to key sections
- update navigation, hero, footer, and contact sections to render database-provided values with safe fallbacks
- keep the contact form hydrated from the API while defaulting to server-provided settings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d931c5eb34832faf6addc472734e7c