### PR TITLE
Remove public sign-in entry points

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -102,8 +102,8 @@ export default function Page() {
                 </div>
                 <div className="mt-4 text-center text-sm">
                   Already have an account?{" "}
-                  <Link href="/auth/login" className="underline underline-offset-4">
-                    Login
+                  <Link href="/admin" className="underline underline-offset-4">
+                    Access the admin portal to log in
                   </Link>
                 </div>
               </form>

--- a/components/auth/admin-login-card.tsx
+++ b/components/auth/admin-login-card.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import type React from "react"
+import { useState } from "react"
+import { useRouter } from "next/navigation"
 
 import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
@@ -8,10 +9,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { useState } from "react"
 
-export default function Page() {
+export function AdminLoginCard() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [error, setError] = useState<string | null>(null)
@@ -25,23 +24,21 @@ export default function Page() {
     setError(null)
 
     try {
-      console.log("[v0] Attempting login with email:", email)
       const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,
         options: {
-          emailRedirectTo: process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL || `${window.location.origin}/admin`,
+          emailRedirectTo:
+            process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL || `${window.location.origin}/admin`,
         },
       })
 
-      console.log("[v0] Login response:", { data, error })
-
       if (error) throw error
 
-      console.log("[v0] Login successful, redirecting to admin")
-      router.push("/admin")
+      if (data?.user) {
+        router.push("/admin")
+      }
     } catch (error: unknown) {
-      console.log("[v0] Login error:", error)
       setError(error instanceof Error ? error.message : "An error occurred")
     } finally {
       setIsLoading(false)

--- a/components/auth/user-menu.tsx
+++ b/components/auth/user-menu.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
+
 import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
 import {
@@ -33,12 +34,12 @@ export function UserMenu() {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
+    } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null)
     })
 
     return () => subscription.unsubscribe()
-  }, [supabase.auth])
+  }, [supabase])
 
   const handleSignOut = async () => {
     await supabase.auth.signOut()
@@ -46,11 +47,7 @@ export function UserMenu() {
   }
 
   if (!user) {
-    return (
-      <Button variant="outline" asChild>
-        <a href="/auth/login">Sign In</a>
-      </Button>
-    )
+    return null
   }
 
   const getInitials = (email: string) => {

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -32,35 +32,14 @@ export async function updateSession(request: NextRequest) {
     },
   )
 
-  // Do not run code between createServerClient and
-  // supabase.auth.getUser(). A simple mistake could make it very hard to debug
-  // issues with users being randomly logged out.
-
-  // IMPORTANT: If you remove getUser() and you use server-side rendering
-  // with the Supabase client, your users may be randomly logged out.
   const {
     data: { user },
   } = await supabase.auth.getUser()
 
-  // Protect admin routes
   if (request.nextUrl.pathname.startsWith("/admin") && !user) {
-    const url = request.nextUrl.clone()
-    url.pathname = "/auth/login"
-    return NextResponse.redirect(url)
+    // Allow unauthenticated visitors to reach /admin so the in-app login form can render
+    return supabaseResponse
   }
-
-  // IMPORTANT: You *must* return the supabaseResponse object as it is.
-  // If you're creating a new response object with NextResponse.next() make sure to:
-  // 1. Pass the request in it, like so:
-  //    const myNewResponse = NextResponse.next({ request })
-  // 2. Copy over the cookies, like so:
-  //    myNewResponse.cookies.setAll(supabaseResponse.cookies.getAll())
-  // 3. Change the myNewResponse object to fit your needs, but avoid changing
-  //    the cookies!
-  // 4. Finally:
-  //    return myNewResponse
-  // If this is not done, you may be causing the browser and server to go out
-  // of sync and terminate the user's session prematurely!
 
   return supabaseResponse
 }


### PR DESCRIPTION
## Summary
- hide the sign-in button from the public navigation when no user is present
- move the login form into the admin auth guard and remove the standalone /auth/login route
- update middleware and sign-up messaging so admins log in via the /admin portal

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e76c181ed0832fbf3f53b884791cb2